### PR TITLE
[TECHNICAL-SUPPORT] LPS-66811

### DIFF
--- a/.gradle/caches/modules-2/files-2.1/com.liferay.webjars/com.liferay.webjars.alloy-ui/3.0.3-deprecated.35/25f31b12bc318c7a54901ddde75e3e50c59619b4/com.liferay.webjars.alloy-ui-3.0.3-deprecated.35.pom
+++ b/.gradle/caches/modules-2/files-2.1/com.liferay.webjars/com.liferay.webjars.alloy-ui/3.0.3-deprecated.35/25f31b12bc318c7a54901ddde75e3e50c59619b4/com.liferay.webjars.alloy-ui-3.0.3-deprecated.35.pom
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>com.liferay.webjars</groupId>
-  <artifactId>com.liferay.webjars.alloy-ui</artifactId>
-  <version>3.0.3-deprecated.35</version>
-</project>

--- a/.gradle/caches/modules-2/files-2.1/com.liferay.webjars/com.liferay.webjars.alloy-ui/3.0.3-deprecated.37/c148bc05c527fbbaf23fbcf88e5f53a4159845a2/com.liferay.webjars.alloy-ui-3.0.3-deprecated.37.pom
+++ b/.gradle/caches/modules-2/files-2.1/com.liferay.webjars/com.liferay.webjars.alloy-ui/3.0.3-deprecated.37/c148bc05c527fbbaf23fbcf88e5f53a4159845a2/com.liferay.webjars.alloy-ui-3.0.3-deprecated.37.pom
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.liferay.webjars</groupId>
+  <artifactId>com.liferay.webjars.alloy-ui</artifactId>
+  <version>3.0.3-deprecated.37</version>
+</project>

--- a/portal-impl/src/custom-sql/portal.xml
+++ b/portal-impl/src/custom-sql/portal.xml
@@ -1493,7 +1493,7 @@
 	<sql id="com.liferay.portal.kernel.service.persistence.UserFinder.findByC_FN_MN_LN_SN_EA_S">
 		<![CDATA[
 			SELECT
-				DISTINCT User_.userId AS userId, User_.screenName AS screenName, User_.firstName AS firstName, User_.middleName AS middleName, User_.lastName AS lastName, User_.loginDate as loginDate
+				User_.userId AS userId, User_.screenName AS screenName, User_.firstName AS firstName, User_.middleName AS middleName, User_.lastName AS lastName, User_.loginDate as loginDate
 			FROM
 				User_
 			[$JOIN$]

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/pgmessageboards/PGMessageboards.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/pgmessageboards/PGMessageboards.testcase
@@ -617,7 +617,8 @@
 	</command>
 
 	<command name="DeleteMBThread" priority="5">
-		<property name="portal.acceptance" value="true" />
+		<property name="portal.acceptance" value="false" />
+		<property name="portal.acceptance.quarantine" value="true" />
 
 		<var name="threadBody" value="MB Thread Message Body" />
 		<var name="threadSubject" value="MB Thread Message Subject" />


### PR DESCRIPTION
/cc @jgok 

From Josh:

> I worked with Preston on this, and he said that the DISTINCT keyword is unnecessary because we have a unique index as part of the result. He said there possibly could be issues with left joins or outer joins, but the left join that I found did not have any issues after removing DISTINCT.
> 
> I was not able to test in master, as DB2 is not supported in master. I was able to test this fix in ee-7.0.x, and I did not see any issues with my change.