### PR TITLE
[TECHNICAL-SUPPORT] LPS-68951

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
@@ -842,8 +842,6 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 			params = _emptyLinkedHashMap;
 		}
 
-		List<LinkedHashMap<String, Object>> paramsMapList = new ArrayList<>();
-
 		Long[] groupIds = null;
 
 		if (params.get("usersGroups") instanceof Long) {
@@ -874,9 +872,35 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 		boolean socialRelationTypeUnionUserGroups = GetterUtil.getBoolean(
 			params.get("socialRelationTypeUnionUserGroups"));
 
-		if (ArrayUtil.isNotEmpty(groupIds) && inherit &&
-			!socialRelationTypeUnionUserGroups) {
+		List<LinkedHashMap<String, Object>> paramsMapList = new ArrayList<>();
 
+		LinkedHashMap<String, Object> params1 = new LinkedHashMap<>(params);
+
+		paramsMapList.add(params1);
+
+		if (socialRelationTypeUnionUserGroups) {
+			boolean hasSocialRelationTypes = Validator.isNotNull(
+				params.get("socialRelationType"));
+
+			if (hasSocialRelationTypes && ArrayUtil.isNotEmpty(groupIds)) {
+				LinkedHashMap<String, Object> params2 = new LinkedHashMap<>(
+					params);
+
+				params1.remove("socialRelationType");
+
+				params2.remove("usersGroups");
+
+				paramsMapList.add(params2);
+			}
+
+			return paramsMapList;
+		}
+
+		if (!inherit) {
+			return paramsMapList;
+		}
+
+		if (ArrayUtil.isNotEmpty(groupIds)) {
 			List<Long> organizationIds = new ArrayList<>();
 			List<Long> siteGroupIds = new ArrayList<>();
 			List<Long> userGroupIds = new ArrayList<>();
@@ -958,9 +982,7 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 			}
 		}
 
-		if (ArrayUtil.isNotEmpty(roleIds) && inherit &&
-			!socialRelationTypeUnionUserGroups) {
-
+		if (ArrayUtil.isNotEmpty(roleIds)) {
 			List<Long> organizationIds = new ArrayList<>();
 			List<Long> siteGroupIds = new ArrayList<>();
 			List<Long> userGroupIds = new ArrayList<>();
@@ -1051,25 +1073,6 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 				paramsMapList.add(params6);
 			}
 		}
-
-		LinkedHashMap<String, Object> params1 = new LinkedHashMap<>(params);
-
-		if (socialRelationTypeUnionUserGroups) {
-			boolean hasSocialRelationTypes = Validator.isNotNull(
-				params.get("socialRelationType"));
-
-			if (hasSocialRelationTypes && ArrayUtil.isNotEmpty(groupIds)) {
-				LinkedHashMap<String, Object> params2 = new LinkedHashMap<>(params);
-
-				params1.remove("socialRelationType");
-
-				params2.remove("usersGroups");
-
-				paramsMapList.add(params2);
-			}
-		}
-
-		paramsMapList.add(0,params1);
 
 		return paramsMapList;
 	}

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
@@ -751,6 +751,102 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 		}
 	}
 
+	protected String getJoin(LinkedHashMap<String, Object> params) {
+		if ((params == null) || params.isEmpty()) {
+			return StringPool.BLANK;
+		}
+
+		StringBundler sb = new StringBundler(params.size());
+
+		for (Map.Entry<String, Object> entry : params.entrySet()) {
+			String key = entry.getKey();
+
+			if (key.equals("expandoAttributes")) {
+				continue;
+			}
+
+			Object value = entry.getValue();
+
+			if (Validator.isNotNull(value)) {
+				sb.append(getJoin(key, value));
+			}
+		}
+
+		return sb.toString();
+	}
+
+	protected String getJoin(String key, Object value) {
+		String join = StringPool.BLANK;
+
+		if (key.equals("contactTwitterSn")) {
+			join = CustomSQLUtil.get(JOIN_BY_CONTACT_TWITTER_SN);
+		}
+		else if (key.equals("groupsOrgs")) {
+			join = CustomSQLUtil.get(JOIN_BY_GROUPS_ORGS);
+		}
+		else if (key.equals("groupsUserGroups")) {
+			join = CustomSQLUtil.get(JOIN_BY_GROUPS_USER_GROUPS);
+		}
+		else if (key.equals("noOrganizations")) {
+			join = CustomSQLUtil.get(JOIN_BY_NO_ORGANIZATIONS);
+		}
+		else if (key.equals("userGroupRole")) {
+			join = CustomSQLUtil.get(JOIN_BY_USER_GROUP_ROLE);
+		}
+		else if (key.equals("usersGroups")) {
+			join = CustomSQLUtil.get(JOIN_BY_USERS_GROUPS);
+		}
+		else if (key.equals("usersOrgs")) {
+			join = CustomSQLUtil.get(JOIN_BY_USERS_ORGS);
+		}
+		else if (key.equals("usersOrgsTree")) {
+			join = CustomSQLUtil.get(JOIN_BY_USERS_ORGS_TREE);
+		}
+		else if (key.equals("usersPasswordPolicies")) {
+			join = CustomSQLUtil.get(JOIN_BY_USERS_PASSWORD_POLICIES);
+		}
+		else if (key.equals("usersRoles")) {
+			join = CustomSQLUtil.get(JOIN_BY_USERS_ROLES);
+		}
+		else if (key.equals("usersTeams")) {
+			join = CustomSQLUtil.get(JOIN_BY_USERS_TEAMS);
+		}
+		else if (key.equals("usersUserGroups")) {
+			join = CustomSQLUtil.get(JOIN_BY_USERS_USER_GROUPS);
+		}
+		else if (key.equals("announcementsDeliveryEmailOrSms")) {
+			join = CustomSQLUtil.get(
+				JOIN_BY_ANNOUNCEMENTS_DELIVERY_EMAIL_OR_SMS);
+		}
+		else if (key.equals("socialMutualRelation")) {
+			join = CustomSQLUtil.get(JOIN_BY_SOCIAL_MUTUAL_RELATION);
+		}
+		else if (key.equals("socialMutualRelationType")) {
+			join = CustomSQLUtil.get(JOIN_BY_SOCIAL_MUTUAL_RELATION_TYPE);
+		}
+		else if (key.equals("socialRelation")) {
+			join = CustomSQLUtil.get(JOIN_BY_SOCIAL_RELATION);
+		}
+		else if (key.equals("socialRelationType")) {
+			join = CustomSQLUtil.get(JOIN_BY_SOCIAL_RELATION_TYPE);
+		}
+		else if (value instanceof CustomSQLParam) {
+			CustomSQLParam customSQLParam = (CustomSQLParam)value;
+
+			join = customSQLParam.getSQL();
+		}
+
+		if (Validator.isNotNull(join)) {
+			int pos = join.indexOf("WHERE");
+
+			if (pos != -1) {
+				join = join.substring(0, pos);
+			}
+		}
+
+		return join;
+	}
+
 	protected List<LinkedHashMap<String, Object>> getParamsMapList(
 		LinkedHashMap<String, Object> params) {
 
@@ -988,102 +1084,6 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 		paramsMapList.add(0,params1);
 
 		return paramsMapList;
-	}
-
-	protected String getJoin(LinkedHashMap<String, Object> params) {
-		if ((params == null) || params.isEmpty()) {
-			return StringPool.BLANK;
-		}
-
-		StringBundler sb = new StringBundler(params.size());
-
-		for (Map.Entry<String, Object> entry : params.entrySet()) {
-			String key = entry.getKey();
-
-			if (key.equals("expandoAttributes")) {
-				continue;
-			}
-
-			Object value = entry.getValue();
-
-			if (Validator.isNotNull(value)) {
-				sb.append(getJoin(key, value));
-			}
-		}
-
-		return sb.toString();
-	}
-
-	protected String getJoin(String key, Object value) {
-		String join = StringPool.BLANK;
-
-		if (key.equals("contactTwitterSn")) {
-			join = CustomSQLUtil.get(JOIN_BY_CONTACT_TWITTER_SN);
-		}
-		else if (key.equals("groupsOrgs")) {
-			join = CustomSQLUtil.get(JOIN_BY_GROUPS_ORGS);
-		}
-		else if (key.equals("groupsUserGroups")) {
-			join = CustomSQLUtil.get(JOIN_BY_GROUPS_USER_GROUPS);
-		}
-		else if (key.equals("noOrganizations")) {
-			join = CustomSQLUtil.get(JOIN_BY_NO_ORGANIZATIONS);
-		}
-		else if (key.equals("userGroupRole")) {
-			join = CustomSQLUtil.get(JOIN_BY_USER_GROUP_ROLE);
-		}
-		else if (key.equals("usersGroups")) {
-			join = CustomSQLUtil.get(JOIN_BY_USERS_GROUPS);
-		}
-		else if (key.equals("usersOrgs")) {
-			join = CustomSQLUtil.get(JOIN_BY_USERS_ORGS);
-		}
-		else if (key.equals("usersOrgsTree")) {
-			join = CustomSQLUtil.get(JOIN_BY_USERS_ORGS_TREE);
-		}
-		else if (key.equals("usersPasswordPolicies")) {
-			join = CustomSQLUtil.get(JOIN_BY_USERS_PASSWORD_POLICIES);
-		}
-		else if (key.equals("usersRoles")) {
-			join = CustomSQLUtil.get(JOIN_BY_USERS_ROLES);
-		}
-		else if (key.equals("usersTeams")) {
-			join = CustomSQLUtil.get(JOIN_BY_USERS_TEAMS);
-		}
-		else if (key.equals("usersUserGroups")) {
-			join = CustomSQLUtil.get(JOIN_BY_USERS_USER_GROUPS);
-		}
-		else if (key.equals("announcementsDeliveryEmailOrSms")) {
-			join = CustomSQLUtil.get(
-				JOIN_BY_ANNOUNCEMENTS_DELIVERY_EMAIL_OR_SMS);
-		}
-		else if (key.equals("socialMutualRelation")) {
-			join = CustomSQLUtil.get(JOIN_BY_SOCIAL_MUTUAL_RELATION);
-		}
-		else if (key.equals("socialMutualRelationType")) {
-			join = CustomSQLUtil.get(JOIN_BY_SOCIAL_MUTUAL_RELATION_TYPE);
-		}
-		else if (key.equals("socialRelation")) {
-			join = CustomSQLUtil.get(JOIN_BY_SOCIAL_RELATION);
-		}
-		else if (key.equals("socialRelationType")) {
-			join = CustomSQLUtil.get(JOIN_BY_SOCIAL_RELATION_TYPE);
-		}
-		else if (value instanceof CustomSQLParam) {
-			CustomSQLParam customSQLParam = (CustomSQLParam)value;
-
-			join = customSQLParam.getSQL();
-		}
-
-		if (Validator.isNotNull(join)) {
-			int pos = join.indexOf("WHERE");
-
-			if (pos != -1) {
-				join = join.substring(0, pos);
-			}
-		}
-
-		return join;
 	}
 
 	protected String getWhere(LinkedHashMap<String, Object> params) {

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
@@ -464,6 +464,8 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 
 			StringBundler sb = new StringBundler(20);
 
+			sb.append("SELECT COUNT(userId) AS COUNT_VALUE FROM (");
+
 			for (int i = 0; i < paramsMapList.size(); i++) {
 				if (i != 0) {
 					sb.append(" UNION ");
@@ -474,13 +476,15 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 				sb.append(StringPool.CLOSE_PARENTHESIS);
 			}
 
+			sb.append(") userId");
+
 			sql = sb.toString();
 
 			sql = CustomSQLUtil.replaceAndOperator(sql, andOperator);
 
 			SQLQuery q = session.createSynchronizedSQLQuery(sql);
 
-			q.addScalar("userId", Type.LONG);
+			q.addScalar("COUNT_VALUE", Type.LONG);
 
 			QueryPos qPos = QueryPos.getInstance(q);
 
@@ -500,10 +504,14 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 				}
 			}
 
-			List<Long> userIds = (List<Long>)QueryUtil.list(
+			List<Long> userCounts = (List<Long>)QueryUtil.list(
 				q, getDialect(), QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
-			return userIds.size();
+			if ((userCounts == null) || userCounts.isEmpty()) {
+				return 0;
+			}
+
+			return userCounts.get(0).intValue();
 		}
 		catch (Exception e) {
 			throw new SystemException(e);

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
@@ -672,17 +672,7 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 			params = _emptyLinkedHashMap;
 		}
 
-		LinkedHashMap<String, Object> params1 = params;
-
-		LinkedHashMap<String, Object> params2 = null;
-
-		LinkedHashMap<String, Object> params3 = null;
-
-		LinkedHashMap<String, Object> params4 = null;
-
-		LinkedHashMap<String, Object> params5 = null;
-
-		LinkedHashMap<String, Object> params6 = null;
+		List<LinkedHashMap<String, Object>> paramsMapList = new ArrayList<>();
 
 		Long[] groupIds = null;
 
@@ -740,7 +730,8 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 			}
 
 			if (!organizationIds.isEmpty()) {
-				params2 = new LinkedHashMap<>(params1);
+				LinkedHashMap<String, Object> params2 = new LinkedHashMap<>(
+					params);
 
 				params2.remove("usersGroups");
 
@@ -756,33 +747,44 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 						"usersOrgsTree",
 						new ArrayList<Organization>(organizations.values()));
 				}
+
+				paramsMapList.add(params2);
 			}
 
 			if (!siteGroupIds.isEmpty()) {
 				Long[] siteGroupIdsArray = siteGroupIds.toArray(
 					new Long[siteGroupIds.size()]);
 
-				params3 = new LinkedHashMap<>(params1);
+				LinkedHashMap<String, Object> params3 = new LinkedHashMap<>(
+					params);
 
 				params3.remove("usersGroups");
 
 				params3.put("groupsOrgs", siteGroupIdsArray);
 
-				params4 = new LinkedHashMap<>(params1);
+				paramsMapList.add(params3);
+
+				LinkedHashMap<String, Object> params4 = new LinkedHashMap<>(
+					params);
 
 				params4.remove("usersGroups");
 
 				params4.put("groupsUserGroups", siteGroupIdsArray);
+
+				paramsMapList.add(params4);
 			}
 
 			if (!userGroupIds.isEmpty()) {
-				params5 = new LinkedHashMap<>(params1);
+				LinkedHashMap<String, Object> params5 = new LinkedHashMap<>(
+					params);
 
 				params5.remove("usersGroups");
 
 				params5.put(
 					"usersUserGroups",
 					userGroupIds.toArray(new Long[userGroupIds.size()]));
+
+				paramsMapList.add(params5);
 			}
 		}
 
@@ -810,7 +812,8 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 			}
 
 			if (!organizationIds.isEmpty()) {
-				params2 = new LinkedHashMap<>(params1);
+				LinkedHashMap<String, Object> params2 = new LinkedHashMap<>(
+					params);
 
 				params2.remove("usersRoles");
 
@@ -829,54 +832,74 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 						"usersOrgsTree",
 						new ArrayList<Organization>(organizations.values()));
 				}
+
+				paramsMapList.add(params2);
 			}
 
 			if (!siteGroupIds.isEmpty()) {
 				Long[] siteGroupIdsArray = siteGroupIds.toArray(
 					new Long[siteGroupIds.size()]);
 
-				params3 = new LinkedHashMap<>(params1);
+				LinkedHashMap<String, Object> params3 = new LinkedHashMap<>(
+					params);
 
 				params3.remove("usersRoles");
 
 				params3.put("usersGroups", siteGroupIdsArray);
 
-				params4 = new LinkedHashMap<>(params1);
+				paramsMapList.add(params3);
+
+				LinkedHashMap<String, Object> params4 = new LinkedHashMap<>(
+					params);
 
 				params4.remove("usersRoles");
 
 				params4.put("groupsOrgs", siteGroupIdsArray);
 
-				params5 = new LinkedHashMap<>(params1);
+				paramsMapList.add(params4);
+
+				LinkedHashMap<String, Object> params5 = new LinkedHashMap<>(
+					params);
 
 				params5.remove("usersRoles");
 
 				params5.put("groupsUserGroups", siteGroupIdsArray);
+
+				paramsMapList.add(params5);
 			}
 
 			if (!userGroupIds.isEmpty()) {
-				params6 = new LinkedHashMap<>(params1);
+				LinkedHashMap<String, Object> params6 = new LinkedHashMap<>(
+					params);
 
 				params6.remove("usersRoles");
 
 				params6.put(
 					"usersUserGroups",
 					userGroupIds.toArray(new Long[userGroupIds.size()]));
+
+				paramsMapList.add(params6);
 			}
 		}
+
+		LinkedHashMap<String, Object> params1 = new LinkedHashMap<>(params);
 
 		if (socialRelationTypeUnionUserGroups) {
 			boolean hasSocialRelationTypes = Validator.isNotNull(
 				params.get("socialRelationType"));
 
 			if (hasSocialRelationTypes && ArrayUtil.isNotEmpty(groupIds)) {
-				params2 = new LinkedHashMap<>(params1);
+				LinkedHashMap<String, Object> params2 = new LinkedHashMap<>(params);
 
 				params1.remove("socialRelationType");
 
 				params2.remove("usersGroups");
+
+				paramsMapList.add(params2);
 			}
 		}
+
+		paramsMapList.add(0,params1);
 
 		Session session = null;
 
@@ -907,37 +930,13 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 
 			StringBundler sb = new StringBundler(20);
 
-			sb.append(StringPool.OPEN_PARENTHESIS);
-			sb.append(replaceJoinAndWhere(sql, params1));
-			sb.append(StringPool.CLOSE_PARENTHESIS);
+			for (int i = 0; i < paramsMapList.size(); i++) {
+				if (i != 0) {
+					sb.append(" UNION ");
+				}
 
-			if (params2 != null) {
-				sb.append(" UNION (");
-				sb.append(replaceJoinAndWhere(sql, params2));
-				sb.append(StringPool.CLOSE_PARENTHESIS);
-			}
-
-			if (params3 != null) {
-				sb.append(" UNION (");
-				sb.append(replaceJoinAndWhere(sql, params3));
-				sb.append(StringPool.CLOSE_PARENTHESIS);
-			}
-
-			if (params4 != null) {
-				sb.append(" UNION (");
-				sb.append(replaceJoinAndWhere(sql, params4));
-				sb.append(StringPool.CLOSE_PARENTHESIS);
-			}
-
-			if (params5 != null) {
-				sb.append(" UNION (");
-				sb.append(replaceJoinAndWhere(sql, params5));
-				sb.append(StringPool.CLOSE_PARENTHESIS);
-			}
-
-			if (params6 != null) {
-				sb.append(" UNION (");
-				sb.append(replaceJoinAndWhere(sql, params6));
+				sb.append(StringPool.OPEN_PARENTHESIS);
+				sb.append(replaceJoinAndWhere(sql, paramsMapList.get(i)));
 				sb.append(StringPool.CLOSE_PARENTHESIS);
 			}
 
@@ -956,86 +955,8 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 
 			QueryPos qPos = QueryPos.getInstance(q);
 
-			setJoin(qPos, params1);
-
-			qPos.add(companyId);
-			qPos.add(false);
-			qPos.add(firstNames, 2);
-			qPos.add(middleNames, 2);
-			qPos.add(lastNames, 2);
-			qPos.add(screenNames, 2);
-			qPos.add(emailAddresses, 2);
-
-			if (status != WorkflowConstants.STATUS_ANY) {
-				qPos.add(status);
-			}
-
-			if (params2 != null) {
-				setJoin(qPos, params2);
-
-				qPos.add(companyId);
-				qPos.add(false);
-				qPos.add(firstNames, 2);
-				qPos.add(middleNames, 2);
-				qPos.add(lastNames, 2);
-				qPos.add(screenNames, 2);
-				qPos.add(emailAddresses, 2);
-
-				if (status != WorkflowConstants.STATUS_ANY) {
-					qPos.add(status);
-				}
-			}
-
-			if (params3 != null) {
-				setJoin(qPos, params3);
-
-				qPos.add(companyId);
-				qPos.add(false);
-				qPos.add(firstNames, 2);
-				qPos.add(middleNames, 2);
-				qPos.add(lastNames, 2);
-				qPos.add(screenNames, 2);
-				qPos.add(emailAddresses, 2);
-
-				if (status != WorkflowConstants.STATUS_ANY) {
-					qPos.add(status);
-				}
-			}
-
-			if (params4 != null) {
-				setJoin(qPos, params4);
-
-				qPos.add(companyId);
-				qPos.add(false);
-				qPos.add(firstNames, 2);
-				qPos.add(middleNames, 2);
-				qPos.add(lastNames, 2);
-				qPos.add(screenNames, 2);
-				qPos.add(emailAddresses, 2);
-
-				if (status != WorkflowConstants.STATUS_ANY) {
-					qPos.add(status);
-				}
-			}
-
-			if (params5 != null) {
-				setJoin(qPos, params5);
-
-				qPos.add(companyId);
-				qPos.add(false);
-				qPos.add(firstNames, 2);
-				qPos.add(middleNames, 2);
-				qPos.add(lastNames, 2);
-				qPos.add(screenNames, 2);
-				qPos.add(emailAddresses, 2);
-
-				if (status != WorkflowConstants.STATUS_ANY) {
-					qPos.add(status);
-				}
-			}
-
-			if (params6 != null) {
-				setJoin(qPos, params6);
+			for (LinkedHashMap<String, Object> paramsMap : paramsMapList) {
+				setJoin(qPos, paramsMap);
 
 				qPos.add(companyId);
 				qPos.add(false);

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
@@ -462,7 +462,20 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 				sql = StringUtil.replace(sql, _STATUS_SQL, StringPool.BLANK);
 			}
 
-			int stringBundlerSize = (paramsMapList.size() * 4) + 1;
+			int stringBundlerSize;
+
+			DB db = getDB();
+
+			boolean sybase = false;
+
+			if (db.getDBType() == DBType.SYBASE) {
+				sybase = true;
+
+				stringBundlerSize = (paramsMapList.size() * 7) + 1;
+			}
+			else {
+				stringBundlerSize = (paramsMapList.size() * 4) + 1;
+			}
 
 			StringBundler sb = new StringBundler(stringBundlerSize);
 
@@ -473,9 +486,18 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 					sb.append(" UNION ");
 				}
 
+				if (sybase) {
+					sb.append("SELECT userId FROM ");
+				}
+
 				sb.append(StringPool.OPEN_PARENTHESIS);
 				sb.append(replaceJoinAndWhere(sql, paramsMapList.get(i)));
 				sb.append(StringPool.CLOSE_PARENTHESIS);
+
+				if (sybase) {
+					sb.append(" params");
+					sb.append(i);
+				}
 			}
 
 			sb.append(") userId");

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
@@ -668,6 +668,92 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 		screenNames = CustomSQLUtil.keywords(screenNames);
 		emailAddresses = CustomSQLUtil.keywords(emailAddresses);
 
+		List<LinkedHashMap<String, Object>> paramsMapList = getParamsMapList(
+			params);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			String sql = CustomSQLUtil.get(FIND_BY_C_FN_MN_LN_SN_EA_S);
+
+			sql = CustomSQLUtil.replaceKeywords(
+				sql, "lower(User_.firstName)", StringPool.LIKE, false,
+				firstNames);
+			sql = CustomSQLUtil.replaceKeywords(
+				sql, "lower(User_.middleName)", StringPool.LIKE, false,
+				middleNames);
+			sql = CustomSQLUtil.replaceKeywords(
+				sql, "lower(User_.lastName)", StringPool.LIKE, false,
+				lastNames);
+			sql = CustomSQLUtil.replaceKeywords(
+				sql, "lower(User_.screenName)", StringPool.LIKE, false,
+				screenNames);
+			sql = CustomSQLUtil.replaceKeywords(
+				sql, "lower(User_.emailAddress)", StringPool.LIKE, true,
+				emailAddresses);
+
+			if (status == WorkflowConstants.STATUS_ANY) {
+				sql = StringUtil.replace(sql, _STATUS_SQL, StringPool.BLANK);
+			}
+
+			StringBundler sb = new StringBundler(20);
+
+			for (int i = 0; i < paramsMapList.size(); i++) {
+				if (i != 0) {
+					sb.append(" UNION ");
+				}
+
+				sb.append(StringPool.OPEN_PARENTHESIS);
+				sb.append(replaceJoinAndWhere(sql, paramsMapList.get(i)));
+				sb.append(StringPool.CLOSE_PARENTHESIS);
+			}
+
+			if (obc != null) {
+				sb.append(" ORDER BY ");
+				sb.append(obc.toString());
+			}
+
+			sql = sb.toString();
+
+			sql = CustomSQLUtil.replaceAndOperator(sql, andOperator);
+
+			SQLQuery q = session.createSynchronizedSQLQuery(sql);
+
+			q.addScalar("userId", Type.LONG);
+
+			QueryPos qPos = QueryPos.getInstance(q);
+
+			for (LinkedHashMap<String, Object> paramsMap : paramsMapList) {
+				setJoin(qPos, paramsMap);
+
+				qPos.add(companyId);
+				qPos.add(false);
+				qPos.add(firstNames, 2);
+				qPos.add(middleNames, 2);
+				qPos.add(lastNames, 2);
+				qPos.add(screenNames, 2);
+				qPos.add(emailAddresses, 2);
+
+				if (status != WorkflowConstants.STATUS_ANY) {
+					qPos.add(status);
+				}
+			}
+
+			return (List<Long>)QueryUtil.list(q, getDialect(), start, end);
+		}
+		catch (Exception e) {
+			throw new SystemException(e);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected List<LinkedHashMap<String, Object>> getParamsMapList(
+		LinkedHashMap<String, Object> params) {
+
 		if (params == null) {
 			params = _emptyLinkedHashMap;
 		}
@@ -901,84 +987,7 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 
 		paramsMapList.add(0,params1);
 
-		Session session = null;
-
-		try {
-			session = openSession();
-
-			String sql = CustomSQLUtil.get(FIND_BY_C_FN_MN_LN_SN_EA_S);
-
-			sql = CustomSQLUtil.replaceKeywords(
-				sql, "lower(User_.firstName)", StringPool.LIKE, false,
-				firstNames);
-			sql = CustomSQLUtil.replaceKeywords(
-				sql, "lower(User_.middleName)", StringPool.LIKE, false,
-				middleNames);
-			sql = CustomSQLUtil.replaceKeywords(
-				sql, "lower(User_.lastName)", StringPool.LIKE, false,
-				lastNames);
-			sql = CustomSQLUtil.replaceKeywords(
-				sql, "lower(User_.screenName)", StringPool.LIKE, false,
-				screenNames);
-			sql = CustomSQLUtil.replaceKeywords(
-				sql, "lower(User_.emailAddress)", StringPool.LIKE, true,
-				emailAddresses);
-
-			if (status == WorkflowConstants.STATUS_ANY) {
-				sql = StringUtil.replace(sql, _STATUS_SQL, StringPool.BLANK);
-			}
-
-			StringBundler sb = new StringBundler(20);
-
-			for (int i = 0; i < paramsMapList.size(); i++) {
-				if (i != 0) {
-					sb.append(" UNION ");
-				}
-
-				sb.append(StringPool.OPEN_PARENTHESIS);
-				sb.append(replaceJoinAndWhere(sql, paramsMapList.get(i)));
-				sb.append(StringPool.CLOSE_PARENTHESIS);
-			}
-
-			if (obc != null) {
-				sb.append(" ORDER BY ");
-				sb.append(obc.toString());
-			}
-
-			sql = sb.toString();
-
-			sql = CustomSQLUtil.replaceAndOperator(sql, andOperator);
-
-			SQLQuery q = session.createSynchronizedSQLQuery(sql);
-
-			q.addScalar("userId", Type.LONG);
-
-			QueryPos qPos = QueryPos.getInstance(q);
-
-			for (LinkedHashMap<String, Object> paramsMap : paramsMapList) {
-				setJoin(qPos, paramsMap);
-
-				qPos.add(companyId);
-				qPos.add(false);
-				qPos.add(firstNames, 2);
-				qPos.add(middleNames, 2);
-				qPos.add(lastNames, 2);
-				qPos.add(screenNames, 2);
-				qPos.add(emailAddresses, 2);
-
-				if (status != WorkflowConstants.STATUS_ANY) {
-					qPos.add(status);
-				}
-			}
-
-			return (List<Long>)QueryUtil.list(q, getDialect(), start, end);
-		}
-		catch (Exception e) {
-			throw new SystemException(e);
-		}
-		finally {
-			closeSession(session);
-		}
+		return paramsMapList;
 	}
 
 	protected String getJoin(LinkedHashMap<String, Object> params) {

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
@@ -678,20 +678,8 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 
 			String sql = CustomSQLUtil.get(FIND_BY_C_FN_MN_LN_SN_EA_S);
 
-			sql = CustomSQLUtil.replaceKeywords(
-				sql, "lower(User_.firstName)", StringPool.LIKE, false,
-				firstNames);
-			sql = CustomSQLUtil.replaceKeywords(
-				sql, "lower(User_.middleName)", StringPool.LIKE, false,
-				middleNames);
-			sql = CustomSQLUtil.replaceKeywords(
-				sql, "lower(User_.lastName)", StringPool.LIKE, false,
-				lastNames);
-			sql = CustomSQLUtil.replaceKeywords(
-				sql, "lower(User_.screenName)", StringPool.LIKE, false,
-				screenNames);
-			sql = CustomSQLUtil.replaceKeywords(
-				sql, "lower(User_.emailAddress)", StringPool.LIKE, true,
+			sql = replaceKeywords(
+				sql, firstNames, middleNames, lastNames, screenNames,
 				emailAddresses);
 
 			if (status == WorkflowConstants.STATUS_ANY) {
@@ -1379,6 +1367,27 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 
 		sql = StringUtil.replace(sql, "[$JOIN$]", getJoin(params));
 		sql = StringUtil.replace(sql, "[$WHERE$]", getWhere(params));
+
+		return sql;
+	}
+
+	protected String replaceKeywords(
+		String sql, String[] firstNames, String[] middleNames,
+		String[] lastNames, String[] screenNames, String[] emailAddresses) {
+
+		sql = CustomSQLUtil.replaceKeywords(
+			sql, "lower(User_.firstName)", StringPool.LIKE, false, firstNames);
+		sql = CustomSQLUtil.replaceKeywords(
+			sql, "lower(User_.middleName)", StringPool.LIKE, false,
+			middleNames);
+		sql = CustomSQLUtil.replaceKeywords(
+			sql, "lower(User_.lastName)", StringPool.LIKE, false, lastNames);
+		sql = CustomSQLUtil.replaceKeywords(
+			sql, "lower(User_.screenName)", StringPool.LIKE, false,
+			screenNames);
+		sql = CustomSQLUtil.replaceKeywords(
+			sql, "lower(User_.emailAddress)", StringPool.LIKE, true,
+			emailAddresses);
 
 		return sql;
 	}

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
@@ -438,12 +438,79 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 		String[] lastNames, String[] screenNames, String[] emailAddresses,
 		int status, LinkedHashMap<String, Object> params, boolean andOperator) {
 
-		List<Long> userIds = doFindByC_FN_MN_LN_SN_EA_S(
-			companyId, firstNames, middleNames, lastNames, screenNames,
-			emailAddresses, status, params, andOperator, QueryUtil.ALL_POS,
-			QueryUtil.ALL_POS, null);
+		firstNames = CustomSQLUtil.keywords(firstNames);
+		middleNames = CustomSQLUtil.keywords(middleNames);
+		lastNames = CustomSQLUtil.keywords(lastNames);
+		screenNames = CustomSQLUtil.keywords(screenNames);
+		emailAddresses = CustomSQLUtil.keywords(emailAddresses);
 
-		return userIds.size();
+		List<LinkedHashMap<String, Object>> paramsMapList = getParamsMapList(
+			params);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			String sql = CustomSQLUtil.get(FIND_BY_C_FN_MN_LN_SN_EA_S);
+
+			sql = replaceKeywords(
+				sql, firstNames, middleNames, lastNames, screenNames,
+				emailAddresses);
+
+			if (status == WorkflowConstants.STATUS_ANY) {
+				sql = StringUtil.replace(sql, _STATUS_SQL, StringPool.BLANK);
+			}
+
+			StringBundler sb = new StringBundler(20);
+
+			for (int i = 0; i < paramsMapList.size(); i++) {
+				if (i != 0) {
+					sb.append(" UNION ");
+				}
+
+				sb.append(StringPool.OPEN_PARENTHESIS);
+				sb.append(replaceJoinAndWhere(sql, paramsMapList.get(i)));
+				sb.append(StringPool.CLOSE_PARENTHESIS);
+			}
+
+			sql = sb.toString();
+
+			sql = CustomSQLUtil.replaceAndOperator(sql, andOperator);
+
+			SQLQuery q = session.createSynchronizedSQLQuery(sql);
+
+			q.addScalar("userId", Type.LONG);
+
+			QueryPos qPos = QueryPos.getInstance(q);
+
+			for (LinkedHashMap<String, Object> paramsMap : paramsMapList) {
+				setJoin(qPos, paramsMap);
+
+				qPos.add(companyId);
+				qPos.add(false);
+				qPos.add(firstNames, 2);
+				qPos.add(middleNames, 2);
+				qPos.add(lastNames, 2);
+				qPos.add(screenNames, 2);
+				qPos.add(emailAddresses, 2);
+
+				if (status != WorkflowConstants.STATUS_ANY) {
+					qPos.add(status);
+				}
+			}
+
+			List<Long> userIds = (List<Long>)QueryUtil.list(
+				q, getDialect(), QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+			return userIds.size();
+		}
+		catch (Exception e) {
+			throw new SystemException(e);
+		}
+		finally {
+			closeSession(session);
+		}
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
@@ -878,11 +878,13 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 
 		paramsMapList.add(params1);
 
-		if (socialRelationTypeUnionUserGroups) {
+		if (socialRelationTypeUnionUserGroups &&
+			ArrayUtil.isNotEmpty(groupIds)) {
+
 			boolean hasSocialRelationTypes = Validator.isNotNull(
 				params.get("socialRelationType"));
 
-			if (hasSocialRelationTypes && ArrayUtil.isNotEmpty(groupIds)) {
+			if (hasSocialRelationTypes) {
 				LinkedHashMap<String, Object> params2 = new LinkedHashMap<>(
 					params);
 

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
@@ -462,7 +462,9 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 				sql = StringUtil.replace(sql, _STATUS_SQL, StringPool.BLANK);
 			}
 
-			StringBundler sb = new StringBundler(20);
+			int stringBundlerSize = (paramsMapList.size() * 4) + 1;
+
+			StringBundler sb = new StringBundler(stringBundlerSize);
 
 			sb.append("SELECT COUNT(userId) AS COUNT_VALUE FROM (");
 
@@ -761,7 +763,9 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 				sql = StringUtil.replace(sql, _STATUS_SQL, StringPool.BLANK);
 			}
 
-			StringBundler sb = new StringBundler(20);
+			int stringBundlerSize = (paramsMapList.size() * 4) + 1;
+
+			StringBundler sb = new StringBundler(stringBundlerSize);
 
 			for (int i = 0; i < paramsMapList.size(); i++) {
 				if (i != 0) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-68951

Same solution than https://github.com/pei-jung/liferay-portal/pull/149 but I have applied the changes requested by @shuyangzhou in https://github.com/shuyangzhou/liferay-portal/pull/3445#issuecomment-260061947

In order to have two methods `countByC_FN_MN_LN_SN_EA_S` and `findByC_FN_MN_LN_SN_EA_S` with the specific SQL and not use a boolean flag, I have refactor original method:
**- commit 1:**  use paramsMapList instead having six variables params1...params6 https://github.com/pei-jung/liferay-portal/pull/157/commits/ebee1b1a4ccb39138fcf8245af0d5bf3e5edfdcf
**- commits 2 and 3:** extract paramsMapList calculations to a new method that will be used by countByC_FN_MN_LN_SN_EA_S and findByC_FN_MN_LN_SN_EA_S https://github.com/pei-jung/liferay-portal/pull/157/commits/70dd0af7f969cdb7b6b19f5b9b2b48132e8312a2 https://github.com/pei-jung/liferay-portal/pull/157/commits/598cb5800f9af4ee703b9134460dc87155656ccf
**- commits 4, 5 and 6:**  minor code improvements https://github.com/pei-jung/liferay-portal/pull/157/commits/f01f4f8282dbfd1dd0f35a77205b5c0d496fa20d https://github.com/pei-jung/liferay-portal/pull/157/commits/2b5be14f23fe39bf1d54380ade29539b979115c5 https://github.com/pei-jung/liferay-portal/pull/157/commits/b7111c721691131642bd32991d547abf98f2b2ba

The code added in previous pull request is included in following commits:
**- commits 7, 8 and 9:** add select count(userId) instead retrieving all users https://github.com/pei-jung/liferay-portal/pull/157/commits/0f85ede1c70781b6a2f5615e5894537f09ea861f https://github.com/pei-jung/liferay-portal/pull/157/commits/30ed19264f319e70fa333668c735f65719e6236a https://github.com/pei-jung/liferay-portal/pull/157/commits/3c3ee93051817420b40596a0f973527d65a43156
**- commit 10:**  special code for sybase, similar to UserFinderImpl.countByGroups added in LPS-57748 (https://github.com/brianchandotcom/liferay-portal/pull/30280)  https://github.com/pei-jung/liferay-portal/pull/157/commits/b390c0e49091b3552d627b289e2a4c631386f608