### PR TITLE
LPS-76369 Portlet preferences are always stored in default scope, even when a custom page scope is created

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/SettingsConfigurationAction.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/SettingsConfigurationAction.java
@@ -257,7 +257,7 @@ public abstract class SettingsConfigurationAction
 		else if (settingsScope.equals("group")) {
 			return SettingsFactoryUtil.getSettings(
 				new GroupServiceSettingsLocator(
-					themeDisplay.getSiteGroupId(), serviceName));
+					themeDisplay.getScopeGroupId(), serviceName));
 		}
 		else if (settingsScope.equals("portletInstance")) {
 			String portletResource = ParamUtil.getString(


### PR DESCRIPTION
Hey @drewbrokke 

Could you please review this pull request?

Please let me know if you're not the reviewer for this component (Portal Configuration) so I can resend the pull request to that person.

Thank you!

Best regards,
István