### PR TITLE
LPS-77312

### DIFF
--- a/modules/apps/collaboration/announcements/announcements-uad-test/src/testIntegration/java/com/liferay/announcements/uad/aggregator/test/AnnouncementsEntryUADEntityAggregatorTest.java
+++ b/modules/apps/collaboration/announcements/announcements-uad-test/src/testIntegration/java/com/liferay/announcements/uad/aggregator/test/AnnouncementsEntryUADEntityAggregatorTest.java
@@ -43,14 +43,18 @@ public class AnnouncementsEntryUADEntityAggregatorTest
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
-	protected void addDataObject(long userId) throws Exception {
+	@Override
+	protected Object addDataObject(long userId) throws Exception {
 		AnnouncementsEntry announcementsEntry =
 			_announcementsEntryUADEntityTestHelper.addAnnouncementsEntry(
 				userId);
 
 		_announcementsEntries.add(announcementsEntry);
+
+		return announcementsEntry;
 	}
 
+	@Override
 	protected String getUADRegistryKey() {
 		return AnnouncementsUADConstants.ANNOUNCEMENTS_ENTRY;
 	}

--- a/modules/apps/collaboration/announcements/announcements-uad-test/src/testIntegration/java/com/liferay/announcements/uad/aggregator/test/AnnouncementsFlagUADEntityAggregatorTest.java
+++ b/modules/apps/collaboration/announcements/announcements-uad-test/src/testIntegration/java/com/liferay/announcements/uad/aggregator/test/AnnouncementsFlagUADEntityAggregatorTest.java
@@ -43,13 +43,17 @@ public class AnnouncementsFlagUADEntityAggregatorTest
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
-	protected void addDataObject(long userId) throws Exception {
+	@Override
+	protected Object addDataObject(long userId) throws Exception {
 		AnnouncementsFlag announcementsFlag =
 			_announcementsFlagUADEntityTestHelper.addAnnouncementsFlag(userId);
 
 		_announcementsFlags.add(announcementsFlag);
+
+		return announcementsFlag;
 	}
 
+	@Override
 	protected String getUADRegistryKey() {
 		return AnnouncementsUADConstants.ANNOUNCEMENTS_FLAG;
 	}

--- a/modules/apps/collaboration/bookmarks/bookmarks-uad-test/src/testIntegration/java/com/liferay/bookmarks/uad/aggregator/test/BookmarksEntryUADEntityAggregatorTest.java
+++ b/modules/apps/collaboration/bookmarks/bookmarks-uad-test/src/testIntegration/java/com/liferay/bookmarks/uad/aggregator/test/BookmarksEntryUADEntityAggregatorTest.java
@@ -45,26 +45,31 @@ public class BookmarksEntryUADEntityAggregatorTest
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
-	public void addDataObjectWithStatusByUserId(
+	@Override
+	public Object addDataObjectWithStatusByUserId(
 			long userId, long statusByUserId)
 		throws Exception {
 
 		BookmarksEntry bookmarksEntry =
-			_bookmarksEntryUADEntityTestHelper.addBookmarksEntry(userId);
+			_bookmarksEntryUADEntityTestHelper.addDataObjectWithStatusByUserId(
+				userId, statusByUserId);
 
 		_bookmarksEntries.add(bookmarksEntry);
 
-		_bookmarksEntryUADEntityTestHelper.setStatusByUserId(
-			bookmarksEntry, statusByUserId);
+		return bookmarksEntry;
 	}
 
-	protected void addDataObject(long userId) throws Exception {
+	@Override
+	protected Object addDataObject(long userId) throws Exception {
 		BookmarksEntry bookmarksEntry =
 			_bookmarksEntryUADEntityTestHelper.addBookmarksEntry(userId);
 
 		_bookmarksEntries.add(bookmarksEntry);
+
+		return bookmarksEntry;
 	}
 
+	@Override
 	protected String getUADRegistryKey() {
 		return BookmarksUADConstants.BOOKMARKS_ENTRY;
 	}

--- a/modules/apps/collaboration/bookmarks/bookmarks-uad-test/src/testIntegration/java/com/liferay/bookmarks/uad/test/BookmarksEntryUADEntityTestHelper.java
+++ b/modules/apps/collaboration/bookmarks/bookmarks-uad-test/src/testIntegration/java/com/liferay/bookmarks/uad/test/BookmarksEntryUADEntityTestHelper.java
@@ -44,12 +44,16 @@ public class BookmarksEntryUADEntityTestHelper {
 			RandomTestUtil.randomString(), serviceContext);
 	}
 
-	public void setStatusByUserId(
-			BookmarksEntry bookmarksEntry, long statusByUserId)
+	public BookmarksEntry addDataObjectWithStatusByUserId(
+			long userId, long statusByUserId)
 		throws Exception {
+
+		BookmarksEntry bookmarksEntry = addBookmarksEntry(userId);
 
 		_bookmarksEntryLocalService.updateStatus(
 			statusByUserId, bookmarksEntry, WorkflowConstants.STATUS_APPROVED);
+
+		return bookmarksEntry;
 	}
 
 	@Reference

--- a/modules/apps/collaboration/comment/.gitrepo
+++ b/modules/apps/collaboration/comment/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 1f43a32a7922bfe20063df18f49e9662473c0a42
+	commit = febaefcf910dceed6804f926965c0fea92670fd7
 	mergebuttonmergecommits = false
 	mode = push
-	parent = f17f65c6e47832a025339c7da4cf3d493913b283
+	parent = 8816bf8e1cae0d20b10c76eccf6859c4e7ae86c7
 	remote = git@github.com:liferay/com-liferay-comment.git

--- a/modules/apps/collaboration/document-library/.gitrepo
+++ b/modules/apps/collaboration/document-library/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 1d4eaad9759fc38cf2e7b1913db543735453a3e1
+	commit = 1e6f2d6d89e4cc9248a202d40d2264d58bcc45a8
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 070c05823d5dfe58148003febfdea5331d55f353
+	parent = 2612f74d88844577e60b6a95a0b9094973390161
 	remote = git@github.com:liferay/com-liferay-document-library.git

--- a/modules/apps/collaboration/message-boards/.gitrepo
+++ b/modules/apps/collaboration/message-boards/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 4d196041efc869b5980f681709c835e731583750
+	commit = f78c0911745855c578cdafc75d7e375353838be9
 	mergebuttonmergecommits = false
 	mode = push
-	parent = f44ceebc7b94cd5486d563522bc08283868eb3c9
+	parent = 5fd7d70ec405e5be13ab845d8f9bd3647dcc40b8
 	remote = git@github.com:liferay/com-liferay-message-boards.git

--- a/modules/apps/foundation/user-associated-data/user-associated-data-test-util/build.gradle
+++ b/modules/apps/foundation/user-associated-data/user-associated-data-test-util/build.gradle
@@ -1,9 +1,10 @@
 dependencies {
+	provided group: "com.liferay", name: "com.liferay.osgi.util", version: "3.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.test", version: "default"
+	provided group: "org.osgi", name: "org.osgi.core", version: "6.0.0"
 	provided project(":apps:foundation:user-associated-data:user-associated-data-api")
 }
-
 liferay {
 	deployDir = file("${liferayHome}/osgi/test")
 }

--- a/modules/apps/foundation/user-associated-data/user-associated-data-test-util/src/main/java/com/liferay/user/associated/data/test/util/BaseUADEntityAggregatorTestCase.java
+++ b/modules/apps/foundation/user-associated-data/user-associated-data-test-util/src/main/java/com/liferay/user/associated/data/test/util/BaseUADEntityAggregatorTestCase.java
@@ -109,7 +109,7 @@ public abstract class BaseUADEntityAggregatorTestCase {
 		Assert.assertEquals(uadEntityId, uadEntity.getUADEntityId());
 	}
 
-	protected abstract void addDataObject(long userId) throws Exception;
+	protected abstract Object addDataObject(long userId) throws Exception;
 
 	protected abstract String getUADRegistryKey();
 

--- a/modules/apps/foundation/user-associated-data/user-associated-data-test-util/src/main/java/com/liferay/user/associated/data/test/util/BaseUADEntityAnonymizerTestCase.java
+++ b/modules/apps/foundation/user-associated-data/user-associated-data-test-util/src/main/java/com/liferay/user/associated/data/test/util/BaseUADEntityAnonymizerTestCase.java
@@ -1,0 +1,183 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.user.associated.data.test.util;
+
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.user.associated.data.aggregator.UADEntityAggregator;
+import com.liferay.user.associated.data.anonymizer.UADEntityAnonymizer;
+import com.liferay.user.associated.data.entity.UADEntity;
+import com.liferay.user.associated.data.registry.UADRegistryUtil;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Noah Sherrill
+ */
+public abstract class BaseUADEntityAnonymizerTestCase {
+
+	@Before
+	public void setUp() throws Exception {
+		_user = UserTestUtil.addUser();
+
+		_uadEntityAggregator = UADRegistryUtil.getUADEntityAggregator(
+			getUADRegistryKey());
+
+		_uadEntityAnonymizer = UADRegistryUtil.getUADEntityAnonymizer(
+			getUADRegistryKey());
+	}
+
+	@Test
+	public void testAutoAnonymize() throws Exception {
+		Object dataObject = addDataObject(_user.getUserId());
+
+		List<UADEntity> uadEntities = _uadEntityAggregator.getUADEntities(
+			_user.getUserId());
+
+		_uadEntityAnonymizer.autoAnonymize(uadEntities.get(0));
+
+		long dataObjectId = getDataObjectId(dataObject);
+
+		Assert.assertTrue(isDataObjectAutoAnonymized(dataObjectId, _user));
+	}
+
+	@Test
+	public void testAutoAnonymizeAll() throws Exception {
+		Object dataObject = addDataObject(TestPropsValues.getUserId());
+		Object dataObjectAutoAnonymize = addDataObject(_user.getUserId());
+
+		_uadEntityAnonymizer.autoAnonymizeAll(_user.getUserId());
+
+		long dataObjectId = getDataObjectId(dataObject);
+
+		Assert.assertFalse(
+			isDataObjectAutoAnonymized(
+				dataObjectId, TestPropsValues.getUser()));
+
+		long dataObjectAutoAnoymizeId = getDataObjectId(
+			dataObjectAutoAnonymize);
+
+		Assert.assertTrue(
+			isDataObjectAutoAnonymized(dataObjectAutoAnoymizeId, _user));
+	}
+
+	@Test
+	public void testAutoAnonymizeAllWithNoDataObject() throws Exception {
+		_uadEntityAnonymizer.autoAnonymizeAll(_user.getUserId());
+	}
+
+	@Test
+	public void testAutoAnonymizeStatusByUserOnly() throws Exception {
+		Assume.assumeTrue(this instanceof WhenHasStatusByUserIdField);
+
+		WhenHasStatusByUserIdField whenHasStatusByUserIdField =
+			(WhenHasStatusByUserIdField)this;
+
+		Object dataObject =
+			whenHasStatusByUserIdField.addDataObjectWithStatusByUserId(
+				TestPropsValues.getUserId(), _user.getUserId());
+
+		List<UADEntity> uadEntities = _uadEntityAggregator.getUADEntities(
+			_user.getUserId());
+
+		_uadEntityAnonymizer.autoAnonymize(uadEntities.get(0));
+
+		long dataObjectId = getDataObjectId(dataObject);
+
+		Assert.assertTrue(isDataObjectAutoAnonymized(dataObjectId, _user));
+	}
+
+	@Test
+	public void testAutoAnonymizeUserOnly() throws Exception {
+		Assume.assumeTrue(this instanceof WhenHasStatusByUserIdField);
+
+		WhenHasStatusByUserIdField whenHasStatusByUserIdField =
+			(WhenHasStatusByUserIdField)this;
+
+		Object dataObject =
+			whenHasStatusByUserIdField.addDataObjectWithStatusByUserId(
+				TestPropsValues.getUserId(), _user.getUserId());
+
+		List<UADEntity> uadEntities = _uadEntityAggregator.getUADEntities(
+			_user.getUserId());
+
+		_uadEntityAnonymizer.autoAnonymize(uadEntities.get(0));
+
+		long dataObjectId = getDataObjectId(dataObject);
+
+		Assert.assertTrue(isDataObjectAutoAnonymized(dataObjectId, _user));
+	}
+
+	@Test
+	public void testDelete() throws Exception {
+		Object dataObject = addDataObject(_user.getUserId());
+
+		List<UADEntity> uadEntities = _uadEntityAggregator.getUADEntities(
+			_user.getUserId());
+
+		_uadEntityAnonymizer.delete(uadEntities.get(0));
+
+		long dataObjectId = getDataObjectId(dataObject);
+
+		Assert.assertTrue(isDataObjectDeleted(dataObjectId));
+	}
+
+	@Test
+	public void testDeleteAll() throws Exception {
+		Object dataObject = addDataObject(TestPropsValues.getUserId());
+		Object dataObjectDelete = addDataObject(_user.getUserId());
+
+		_uadEntityAnonymizer.deleteAll(_user.getUserId());
+
+		long dataObjectId = getDataObjectId(dataObject);
+
+		Assert.assertFalse(isDataObjectDeleted(dataObjectId));
+
+		long dataObjectDeleteId = getDataObjectId(dataObjectDelete);
+
+		Assert.assertTrue(isDataObjectDeleted(dataObjectDeleteId));
+	}
+
+	@Test
+	public void testDeleteAllWithNoDataObject() throws Exception {
+		_uadEntityAnonymizer.deleteAll(_user.getUserId());
+	}
+
+	protected abstract Object addDataObject(long userId) throws Exception;
+
+	protected abstract long getDataObjectId(Object dataObject);
+
+	protected abstract String getUADRegistryKey();
+
+	protected abstract boolean isDataObjectAutoAnonymized(
+			long dataObjectId, User user)
+		throws Exception;
+
+	protected abstract boolean isDataObjectDeleted(long dataObjectId);
+
+	private UADEntityAggregator _uadEntityAggregator;
+	private UADEntityAnonymizer _uadEntityAnonymizer;
+
+	@DeleteAfterTestRun
+	private User _user;
+
+}

--- a/modules/apps/foundation/user-associated-data/user-associated-data-test-util/src/main/java/com/liferay/user/associated/data/test/util/WhenHasStatusByUserIdField.java
+++ b/modules/apps/foundation/user-associated-data/user-associated-data-test-util/src/main/java/com/liferay/user/associated/data/test/util/WhenHasStatusByUserIdField.java
@@ -19,7 +19,7 @@ package com.liferay.user.associated.data.test.util;
  */
 public interface WhenHasStatusByUserIdField {
 
-	public void addDataObjectWithStatusByUserId(
+	public Object addDataObjectWithStatusByUserId(
 			long userId, long statusByUserId)
 		throws Exception;
 

--- a/modules/apps/web-experience/asset/.gitrepo
+++ b/modules/apps/web-experience/asset/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 63cc8de7a0927e8ca10fd3d8ae96d2090c522f8c
+	commit = 6af194f7389f70a5d647087ea57076d01c638a5e
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 4517452fc7783f644bc55a73212c0f03d7d11740
+	parent = 3d8275c7c64cfffa1f671345932bf359b73b20fa
 	remote = git@github.com:liferay/com-liferay-asset.git

--- a/readme/7.1/BREAKING_CHANGES.markdown
+++ b/readme/7.1/BREAKING_CHANGES.markdown
@@ -161,7 +161,7 @@ portlet URLs without passing the request as a necessary parameter.
 #### What changed?
 
 The Users File Uploads portlet properties have been moved from Server
-Administration to an OSGI configuration named
+Administration to an OSGi configuration named
 `UserFileUploadsConfiguration.java` in the `users-admin-api` module.
 
 #### Who is affected?


### PR DESCRIPTION
@drewbrokke, the last commit eliminates usage of the UADRegistry within the test code. I could not get the `@Inject` annotation to work here. The problem with that approach appears to be that the base test case is in a separate module from the derived tests. Using `ServiceTrackers` works, so that is the approach I ultimately took, although it is less elegant. If you know of a better way, please let me know.

/cc @willnewbury, @JorgeFerrer