### PR TITLE
LPS-75377 Update package name according to GitId:650b483204622b79204c…

### DIFF
--- a/modules/apps/foundation/configuration-admin/configuration-admin-api/bnd.bnd
+++ b/modules/apps/foundation/configuration-admin/configuration-admin-api/bnd.bnd
@@ -2,7 +2,7 @@ Bundle-Name: Liferay Configuration Admin API
 Bundle-SymbolicName: com.liferay.configuration.admin.api
 Bundle-Version: 1.0.0
 Export-Package:\
-	com.liferay.configuration.admin.categories,\
+	com.liferay.configuration.admin.category,\
 	com.liferay.configuration.admin.constants,\
 	com.liferay.configuration.admin.definition
 Liferay-Releng-Module-Group-Description:


### PR DESCRIPTION
Hi @pei-jung,
For our benchmark test, we find that the bundle com.liferay.configuration.admin.web did not start during the startup of portal, after digging into it,  the root cause of this issue should be the package name in the bnd file need be updated.

> ERROR [localhost-startStop-1][ModuleFrameworkImpl:1572] Unable to start bundle com.liferay.configuration.admin.web
org.osgi.framework.BundleException: Could not resolve module: com.liferay.configuration.admin.web [297]
  Unresolved requirement: Import-Package: com.liferay.configuration.admin.category

Thanks
Lily
