### PR TITLE
LPS-89521

### DIFF
--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_site_role.jspf
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_site_role.jspf
@@ -31,7 +31,7 @@ if (step == 1) {
 	String keywords = ParamUtil.getString(request, "keywords");
 
 	if (Validator.isNull(keywords)) {
-		groups = selUser.getGroups();
+		groups = GroupLocalServiceUtil.getUserGroups(selUser.getUserId(), true);
 	}
 	else {
 		LinkedHashMap<String, Object> groupParams = new LinkedHashMap<>();

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/display/context/UserDisplayContext.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/display/context/UserDisplayContext.java
@@ -106,7 +106,8 @@ public class UserDisplayContext {
 		List<Group> groups = Collections.emptyList();
 
 		if (_selUser != null) {
-			groups = _selUser.getGroups();
+			groups = GroupLocalServiceUtil.getUserGroups(
+				_selUser.getUserId(), true);
 
 			if (_initDisplayContext.isFilterManageableGroups()) {
 				groups = UsersAdminUtil.filterGroups(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPP-32777
https://issues.liferay.com/browse/LPS-89521

From @wanderlast:

> This issue is relatively straightforward. Currently, if a user inherits a site through an organization that it is a member of (say OrgA is a member of TestSite and User1 is a member of OrgA)--User1 should therefore be a member of TestSite and be able to be assigned a site role for TestSite. This works correctly if you navigate to TestSite > Memberships > Users (User1 is listed properly) and then assign them a role through this menu. However, if you go through the Users and Organizations menu and Edit User > Roles, the option to add them does not appear. This is due to the use of selUser.getGroups() which specifically ignores any inherited groups. The change is to use an API that can account for and allow inherited groups to also be included. Please let me know if you have any questions. Thanks!

Passing SF tests here: https://github.com/ChrisKian/liferay-portal/pull/89#issuecomment-458372698
Passing Relevent tests here: https://github.com/ChrisKian/liferay-portal/pull/89#issuecomment-458393980