### PR TITLE
LPS-89521

### DIFF
--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_site_role.jspf
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_site_role.jspf
@@ -31,7 +31,7 @@ if (step == 1) {
 	String keywords = ParamUtil.getString(request, "keywords");
 
 	if (Validator.isNull(keywords)) {
-		groups = selUser.getGroups();
+		groups = selUser.getSiteGroups();
 	}
 	else {
 		LinkedHashMap<String, Object> groupParams = new LinkedHashMap<>();

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
@@ -19,6 +19,7 @@
 <%
 User selUser = userDisplayContext.getSelectedUser();
 List<Group> groups = userDisplayContext.getGroups();
+List<Group> inheritedSites = userDisplayContext.getInheritedSites();
 List<Organization> organizations = userDisplayContext.getOrganizations();
 Long[] organizationIds = UsersAdminUtil.getOrganizationIds(organizations);
 List<Role> roles = userDisplayContext.getRoles();
@@ -451,7 +452,7 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 		<div class="text-muted"><liferay-ui:message key="this-user-does-not-belong-to-a-site-to-which-a-site-role-can-be-assigned" /></div>
 	</c:if>
 
-	<c:if test="<%= !groups.isEmpty() %>">
+	<c:if test="<%= !groups.isEmpty() || !inheritedSites.isEmpty() %>">
 		<liferay-ui:search-container
 			compactEmptyResultsMessage="<%= true %>"
 			cssClass="lfr-search-container-site-roles"


### PR DESCRIPTION
https://issues.liferay.com/browse/LPP-32777
https://issues.liferay.com/browse/LPS-89521

From @wanderlast: 

> I've made adjustments based on the suggestions made in https://github.com/pei-jung/liferay-portal/pull/337. Specifically:
> 
> 1. The check for inherited sites is made separate. Therefore, we check for if groups OR a separately retrieved list of inherited sites are empty, rather than including inherited sites in the group check.
> 2. We retrieve only site groups in select_site_role.jspf. The current method retrieves only site groups that are not explicitly assigned. getSiteGroups() retrieves all site groups whether inherited or not.
> 
> Please let me know if you have any questions or concerns. Thanks! 

Passing SF test here: https://github.com/ChrisKian/liferay-portal/pull/94#issuecomment-459546852
Passing relevant tests here: https://github.com/ChrisKian/liferay-portal/pull/94#issuecomment-459565971
(Failures seem unrelated)