### PR TITLE
LPS-91588

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -5026,29 +5026,6 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 			}
 		}
 
-		String screenName = friendlyURL.substring(1);
-
-		User user = userPersistence.fetchByC_SN(companyId, screenName);
-
-		if (user != null) {
-			long userClassNameId = classNameLocalService.getClassNameId(
-				User.class);
-
-			if ((classNameId == userClassNameId) &&
-				(classPK == user.getUserId())) {
-			}
-			else {
-				GroupFriendlyURLException gfurle =
-					new GroupFriendlyURLException(
-						GroupFriendlyURLException.DUPLICATE);
-
-				gfurle.setDuplicateClassPK(user.getUserId());
-				gfurle.setDuplicateClassName(User.class.getName());
-
-				throw gfurle;
-			}
-		}
-
 		if (StringUtil.count(friendlyURL, CharPool.SLASH) > 1) {
 			throw new GroupFriendlyURLException(
 				GroupFriendlyURLException.TOO_DEEP);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-91588

User screenname/friendlyURL duplication check is already done [here](https://github.com/pei-jung/liferay-portal/compare/master...ChrisKian:LPS-91588?expand=1#diff-aed545163a3676249d8003fbb6a4e6a9R4996), so there is no need to do it again.  By removing this second unnecessary check, we are able to avoid the issue described in LPS-91588 which relates specifically to DB2 column sizes.

Please let me know if you have any questions, thanks!