### PR TITLE
LPS-90864 Let user view groups he's member of

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/GroupServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupServiceImpl.java
@@ -1191,11 +1191,14 @@ public class GroupServiceImpl extends GroupServiceBaseImpl {
 	protected List<Group> filterGroups(List<Group> groups)
 		throws PortalException {
 
+		PermissionChecker permissionChecker = getPermissionChecker();
+
 		List<Group> filteredGroups = new ArrayList<>();
 
 		for (Group group : groups) {
 			if (GroupPermissionUtil.contains(
-					getPermissionChecker(), group, ActionKeys.VIEW)) {
+					permissionChecker, group, ActionKeys.VIEW) ||
+				permissionChecker.isGroupMember(group.getGroupId())) {
 
 				filteredGroups.add(group);
 			}


### PR DESCRIPTION
Hey @pei-jung

I think you're responsible for this part of the product. Feel free to
forward if this is not the case.

When filtering out results, the search methods are excluding sites to
which the users belong. It seems natural for site members to be able
to see groups they belong to.

I've changed the "filter" method instead of adding this check to the
group permission infrastructure, as I'm not sure of the impact in
other parts of the portal.

Thanks!