### PR TITLE
LPS-94191 Custom Field Geolocation with spaces in the name causes an Uncaught DOMException

### DIFF
--- a/modules/apps/expando/expando-taglib/src/main/resources/META-INF/resources/custom_attribute/page.jsp
+++ b/modules/apps/expando/expando-taglib/src/main/resources/META-INF/resources/custom_attribute/page.jsp
@@ -302,6 +302,10 @@ ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(company.
 								<div class="glyphicon glyphicon-map-marker" id="<%= portletDisplay.getNamespace()+"ExpandoAttribute--" + name + "--Location" %>">
 								</div>
 
+								<%
+								name = StringUtil.replace(name, ' ', "-");
+								%>
+
 								<liferay-map:map-display
 									geolocation="<%= true %>"
 									latitude='<%= geolocationJSONObject.getDouble("latitude", 0) %>'


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-94191