### PR TITLE
LPS-81716

### DIFF
--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language.properties
@@ -1,3 +1,4 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory.
 max-size-help=Set the maximum upload servlet request content length. Default is 1024 * 1024 * 100.
 overall-maximum-upload-request-size=Overall Maximum Upload Request Size
 temp-dir-help=Set the temporary directory for uploaded files.

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language.properties
@@ -1,6 +1,6 @@
 invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory.
 max-size-help=Set the maximum upload servlet request content length. Default is 1024 * 1024 * 100.
 overall-maximum-upload-request-size=Overall Maximum Upload Request Size
-temp-dir-help=Set the temporary directory for uploaded files.
+temp-dir-help=Set the temporary directory for uploaded files.  A blank value will set the configuration back to the default value.
 temporary-storage-directory=Temporary Storage Directory
 upload-servlet-request-configuration-name=Upload Servlet Request

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language.properties
@@ -1,6 +1,6 @@
 invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory.
 max-size-help=Set the maximum upload servlet request content length. Default is 1024 * 1024 * 100.
 overall-maximum-upload-request-size=Overall Maximum Upload Request Size
-temp-dir-help=Set the temporary directory for uploaded files.  A blank value will set the configuration back to the default value.
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value.
 temporary-storage-directory=Temporary Storage Directory
 upload-servlet-request-configuration-name=Upload Servlet Request

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_ar.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=قم بتعيين أقصى طول لمحتوى طلب تحميل servlet. القيمة الافتراضية هي 1024 * 1024 * 100.
 overall-maximum-upload-request-size=الحد الأقصى لحجم طلب التحميل الكلي
-temp-dir-help=قم بتعيين الدليل المؤقت للملفات المحملة.
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=دليل تخزين مؤقت
 upload-servlet-request-configuration-name=تحميل طلب Servlet

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_bg.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Задаване на максималното качване servlet заявка съдържание дължина. По подразбиране е 1024 * 1024 * 100. (Automatic Translation)
 overall-maximum-upload-request-size=Общото максимално качване искане размер (Automatic Translation)
-temp-dir-help=Определя временната директория за качените файлове. (Automatic Translation)
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Временно съхранение директория (Automatic Translation)
 upload-servlet-request-configuration-name=Качване на Servlet заявка (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_ca.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Estableix la llargada màxima del contingut de la sol·licitud del servlet de càrrega. Per defecte és 1024 * 1024 * 100.
 overall-maximum-upload-request-size=Nombre màxim total de peticions de pujada
-temp-dir-help=Estableix el directori temporal dels fitxers carregats.
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Directori d'emmagatzematge temporal
 upload-servlet-request-configuration-name=Sol·licitud del servlet de càrrega

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_cs.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Nastavení délky obsahu požadavku maximální upload servlet. Výchozí hodnota je 1024 * 1024 * 100. (Automatic Translation)
 overall-maximum-upload-request-size=Celková velikost požadavku maximální uložení (Automatic Translation)
-temp-dir-help=Nastavte dočasný adresář pro soubory. (Automatic Translation)
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Adresář dočasného úložiště
 upload-servlet-request-configuration-name=Servlet požadavek na upload (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_da.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Set the maximum upload servlet request content length. Default is 1024 * 1024 * 100. (Automatic Copy)
 overall-maximum-upload-request-size=Samlede maksimale Upload anmodning størrelse (Automatic Translation)
-temp-dir-help=Set the temporary directory for uploaded files. (Automatic Copy)
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Temporær lagermappen
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_de.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Legen Sie die maximale Inhaltslänge für Servlet Upload-Requests fest. Standard ist 1024 * 1024 * 100.
 overall-maximum-upload-request-size=Maximale Gesamtgröße von Upload-Requests
-temp-dir-help=Legen Sie das vorübergehende Directory für hochgeladene Dateien fest.
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Temporäres Verzeichnis
 upload-servlet-request-configuration-name=Servlet Upload-Request

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_el.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Για να ορίσετε το μέγιστο upload servlet αίτηση μήκος περιεχομένου. Η προεπιλογή είναι 1024 * 1024 * 100. (Automatic Translation)
 overall-maximum-upload-request-size=Συνολικά μέγιστος φορτώνω μέγεθος αίτηση (Automatic Translation)
-temp-dir-help=Για να ορίσετε τον προσωρινό κατάλογο για τα μεταφορτωμένα αρχεία. (Automatic Translation)
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Κατάλογος προσωρινής αποθήκευσης
 upload-servlet-request-configuration-name=Αποστολή αιτήματος Servlet (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_en.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory.
 max-size-help=Set the maximum upload servlet request content length. Default is 1024 * 1024 * 100.
 overall-maximum-upload-request-size=Overall Maximum Upload Request Size
-temp-dir-help=Set the temporary directory for uploaded files.
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value.
 temporary-storage-directory=Temporary Storage Directory
 upload-servlet-request-configuration-name=Upload Servlet Request

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_es.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Establece la longitud máxima del contenido de la solicitud de carga del servlet. El valor por defecto es 1024 * 1024 * 100.
 overall-maximum-upload-request-size=Tamaño máximo total de la solicitud
-temp-dir-help=Establece el directorio temporal de los archivos cargados.
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Directorio del almacenamiento temporal
 upload-servlet-request-configuration-name=Solicitud de carga de servlet

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_et.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Määrake Maksimaalne üleslaadimise servlet taotluse sisu. Vaikimisi on 1024 * 1024 * 100. (Automatic Translation)
 overall-maximum-upload-request-size=Üldine taotlus Üleslaadimismahu (Automatic Translation)
-temp-dir-help=Määrata ajutise kausta üles laaditud faile. (Automatic Translation)
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Ajutine salvestuskataloog
 upload-servlet-request-configuration-name=Lisamise kuupäev Servlet taotluse (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_eu.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Set the maximum upload servlet request content length. Default is 1024 * 1024 * 100. (Automatic Copy)
 overall-maximum-upload-request-size=Overall Maximum Upload Request Size (Automatic Copy)
-temp-dir-help=Set the temporary directory for uploaded files. (Automatic Copy)
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Aldi baterako biltegi direktorioa
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_fa.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=تنظیم حداکثر آپلود servlet درخواست طول محتوا. پیش فرض 1024 * 1024 * 100 است. (Automatic Translation)
 overall-maximum-upload-request-size=حداکثر سایز بارگذاری موردنیاز
-temp-dir-help=مجموعه دایرکتوری موقت برای فایل های آپلود شده. (Automatic Translation)
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=پوشه‌ی ذخیره‌ی دائمی
 upload-servlet-request-configuration-name=ارسال درخواست Servlet (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_fi.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Asettaa suurimman sisäänlatauksen palvelinsovelman pyynnön sisällön pituuden. Oletusarvo on 1024 * 1024 * 100.
 overall-maximum-upload-request-size=Yleinen suurin sisääntuonnin kokorajoitus
-temp-dir-help=Aseta ladattujen tieodstojen väliaikaishakemisto.
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Väliaikaisen tallennuspaikan hakemisto
 upload-servlet-request-configuration-name=Sisääntuonnin Palvelinsovelman Pyyntö

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_fr.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Définissez la taille maximum du contenu de la requête servlet du téléchargement. Par défaut : 1024 * 1024 * 100.
 overall-maximum-upload-request-size=Taille de demande de téléchargement maximum globale
-temp-dir-help=Définissez le répertoire temporaire pour les fichiers téléversés.
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Annuaire de mémoire temporaire
 upload-servlet-request-configuration-name=Requête servlet de téléversement

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_gl.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Set the maximum upload servlet request content length. Default is 1024 * 1024 * 100. (Automatic Copy)
 overall-maximum-upload-request-size=Overall Maximum Upload Request Size (Automatic Copy)
-temp-dir-help=Set the temporary directory for uploaded files. (Automatic Copy)
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Directorio de almacenamento temporal
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_hi_IN.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=अधिकतम अपलोड servlet अनुरोध सामग्री लंबाई सेट करें। डिफ़ॉल्ट 1024 * 1024 * 100 है। (Automatic Translation)
 overall-maximum-upload-request-size=कुल मिलाकर अधिकतम अपलोड अनुरोध आकार (Automatic Translation)
-temp-dir-help=अपलोड की गई फ़ाइलों के लिए अस्थायी निर्देशिका सेट करें। (Automatic Translation)
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=अस्थायी स्टोरेज डाइरेक्टरी
 upload-servlet-request-configuration-name=Servlet अनुरोध अपलोड करें (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_hr.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Set the maximum upload servlet request content length. Default is 1024 * 1024 * 100. (Automatic Copy)
 overall-maximum-upload-request-size=Overall Maximum Upload Request Size (Automatic Copy)
-temp-dir-help=Set the temporary directory for uploaded files. (Automatic Copy)
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Privremenog skladištenja Directory
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_hu.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Állítsa be a maximális feltöltési servlet-kérelem tartalmának a hosszát. Az alapértelmezett érték 1024 * 1024 * 100.
 overall-maximum-upload-request-size=Átfogó maximális feltöltési kérés méret
-temp-dir-help=Állítsa be a feltöltött fájlok ideiglenes könyvtárát.
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Átmeneti tárolómappa
 upload-servlet-request-configuration-name=Servlet feltöltési kérelem

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_in.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Menetapkan maksimum meng-upload servlet permintaan konten panjang. Default adalah 1024 * 1024 * 100. (Automatic Translation)
 overall-maximum-upload-request-size=Secara keseluruhan ukuran maksimum meng-Upload permintaan (Automatic Translation)
-temp-dir-help=Mengatur direktori sementara untuk upload file. (Automatic Translation)
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Penyimpanan Direktori sementara
 upload-servlet-request-configuration-name=Meng-upload Servlet permintaan (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_it.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Imposta la dimensione massima degli upload. Il valore predefinito è 1024 * 1024 * 100.
 overall-maximum-upload-request-size=Dimensione Complessiva Massima File da Caricare
-temp-dir-help=Imposta la cartella temporanea per il caricamento di file.
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Directory Archiviazione Provvisoria
 upload-servlet-request-configuration-name=Upload Servlet Request

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_iw.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=הגדר אורך תוכן בקשת העלאת servlet מרבי. ברירת המחדל היא 1024 * 1024 * 100.
 overall-maximum-upload-request-size=גודל בקשת ההעלאה הכולל המקסימלי
-temp-dir-help=הגדר את הספרייה הזמנית לקבצים שהועלו.
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=תיקיית אחסון זמנית
 upload-servlet-request-configuration-name=העלה בקשת Servlet

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_ja.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=アップロードサーブレットリクエストコンテンツ長の最大値を設定します。
 overall-maximum-upload-request-size=合計最大アップロードリクエストサイズ
-temp-dir-help=アップロードファイルの一時ディレクトリを設定します。
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=一時ファイル用ディレクトリ
 upload-servlet-request-configuration-name=アップロードサーブレットリクエスト

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_kk.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Set the maximum upload servlet request content length. Default is 1024 * 1024 * 100. (Automatic Copy)
 overall-maximum-upload-request-size=Overall Maximum Upload Request Size (Automatic Copy)
-temp-dir-help=Set the temporary directory for uploaded files. (Automatic Copy)
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Temporary Storage Directory (Automatic Copy)
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_ko.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=최대 업로드 서블릿 요청 콘텐츠 길이 설정 합니다. 기본값은 1024 * 1024 * 100입니다. (Automatic Translation)
 overall-maximum-upload-request-size=전반적인 최대 업로드 요청 크기 (Automatic Translation)
-temp-dir-help=업로드 된 파일에 대 한 임시 디렉터리를 설정 합니다. (Automatic Translation)
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=임시 기억 장소 전화번호부
 upload-servlet-request-configuration-name=서블릿 요청 업로드 (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_lo.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Set the maximum upload servlet request content length. Default is 1024 * 1024 * 100. (Automatic Copy)
 overall-maximum-upload-request-size=Overall Maximum Upload Request Size (Automatic Copy)
-temp-dir-help=Set the temporary directory for uploaded files. (Automatic Copy)
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=ດາຍເລັກໂຕລີ້ການສຳຮອງຊົ່ວຄາວ
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_lt.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Nustatytas maksimalus nusiuntimo servlet prašymo turinio ilgis. Numatytasis parametras yra 1024 * 1024 * 100. (Automatic Translation)
 overall-maximum-upload-request-size=Apskritai didžiausias nusiunčiamo prašymą dydis (Automatic Translation)
-temp-dir-help=Nustatyti laikiną katalogą failus. (Automatic Translation)
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Laikinojo saugojimo katalogas (Automatic Translation)
 upload-servlet-request-configuration-name=Įkelti Servlet prašymą (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_nb.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Angi den maksimale opplastingshastigheten servlet forespørsel innholdslengden. Standarden er 1024 * 1024 * 100. (Automatic Translation)
 overall-maximum-upload-request-size=Samlet maksimal forespørsel opplastingsstørrelse (Automatic Translation)
-temp-dir-help=Angi den midlertidige katalogen for opplastede filer. (Automatic Translation)
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Midlertidig lagringskatalog
 upload-servlet-request-configuration-name=Laste opp Servlet forespørsel (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_nl.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Stel de maximale lengte in voor de inhoud van het uploadverzoek van de servlet. Standaard 1024 * 1024 * 100.
 overall-maximum-upload-request-size=Algehele maximale grootte voor uploadverzoeken
-temp-dir-help=Stel de tijdelijke directory in voor geüploade bestanden.
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Tijdelijke opslagmap
 upload-servlet-request-configuration-name=Uploadverzoek servlet

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_nl_BE.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Set the maximum upload servlet request content length. Default is 1024 * 1024 * 100. (Automatic Copy)
 overall-maximum-upload-request-size=Over het geheel genomen maximale Upload verzoek grootte (Automatic Translation)
-temp-dir-help=Set the temporary directory for uploaded files. (Automatic Copy)
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Tijdelijke opslag map
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_pl.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Ustawianie długości zawartości żądania servlet maksymalnego. Wartość domyślna to 1024 * 1024 * 100. (Automatic Translation)
 overall-maximum-upload-request-size=Ogólny rozmiar żądanie maksymalny Upload (Automatic Translation)
-temp-dir-help=Ustaw katalog tymczasowy do przesłanych plików. (Automatic Translation)
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Tymczasowy katalog główny przechowywania danych
 upload-servlet-request-configuration-name=Prześlij żądanie Servlet (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_pt_BR.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Definir o tamanho máximo do conteúdo da solicitação do servlet de upload. O padrão é 1024 * 1024 * 100.
 overall-maximum-upload-request-size=Tamanho Máximo Total da Solicitação de Transferência
-temp-dir-help=Definir o diretório temporário para arquivos carregados.
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Diretório de armazenamento provisório
 upload-servlet-request-configuration-name=Solicitar servlet de upload

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_pt_PT.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Defina o tamanho do conteúdo de solicitação upload máximo servlet. O padrão é 1024 * 1024 * 100. (Automatic Translation)
 overall-maximum-upload-request-size=Tamanho Máximo Global para Pedido de Upload
-temp-dir-help=Defina o diretório temporário para arquivos carregados. (Automatic Translation)
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Directoria de Armazenamento Temporário
 upload-servlet-request-configuration-name=Enviar pedido de Servlet (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_ro.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Stabili o lungime de conţinut maximă de încărcare servlet cerere. Implicit este de 1024 * 1024 * 100. (Automatic Translation)
 overall-maximum-upload-request-size=Dimensiunea de cererea totală maximă de încărcare (Automatic Translation)
-temp-dir-help=Setaţi directorul temporar pentru fişierele încărcate. (Automatic Translation)
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Director de Stocare Temporar
 upload-servlet-request-configuration-name=Încărcaţi Servlet cerere (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_ru.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Задайте длину содержимого запроса сервлета максимальной загрузки. Значение по умолчанию — 1024 * 1024 * 100. (Automatic Translation)
 overall-maximum-upload-request-size=Общий максимальный размер запроса (Automatic Translation)
-temp-dir-help=Установите временный каталог для загруженных файлов. (Automatic Translation)
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Директория временного хранения
 upload-servlet-request-configuration-name=Добавлено сервлета запроса (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_sk.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Nastavte maximálnu upload servlet požiadavka dĺžka obsahu. Predvolená hodnota je 1024 * 1024 * 100. (Automatic Translation)
 overall-maximum-upload-request-size=Celková maximálna požiadavka veľkosť odovzdania (Automatic Translation)
-temp-dir-help=Nastavenie dočasného adresára pre nahrané súbory. (Automatic Translation)
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Priečinok pre dočasné ukladanie
 upload-servlet-request-configuration-name=Servlet požiadavka na upload (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_sl.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Nastavite največjo upload servlet zahtevo vsebine dolžino. Privzeto je 1024 * 1024 * 100. (Automatic Translation)
 overall-maximum-upload-request-size=Splošno največ Upload zahtevo velikost (Automatic Translation)
-temp-dir-help=Nastaviti začasnega imenika za naložene datoteke. (Automatic Translation)
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Začasni imenik za shranjevanje
 upload-servlet-request-configuration-name=Upload Servlet zahtevo (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_sr_RS.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Set the maximum upload servlet request content length. Default is 1024 * 1024 * 100. (Automatic Copy)
 overall-maximum-upload-request-size=Overall Maximum Upload Request Size (Automatic Copy)
-temp-dir-help=Set the temporary directory for uploaded files. (Automatic Copy)
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Привремено Складиште Директоријум
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Set the maximum upload servlet request content length. Default is 1024 * 1024 * 100. (Automatic Copy)
 overall-maximum-upload-request-size=Overall Maximum Upload Request Size (Automatic Copy)
-temp-dir-help=Set the temporary directory for uploaded files. (Automatic Copy)
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Privremeno Skladište Direktorijum
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_sv.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Ange maximal innehållslängd för uppladdning av servlet-begäran. Standard är 1024 * 1024 * 100.
 overall-maximum-upload-request-size=Maximal storlek på överföringsbegäran
-temp-dir-help=Ange en tillfällig katalog för överförda filer.
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Tillfällig lagringsmapp
 upload-servlet-request-configuration-name=Överför servlet-begäran

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_th.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=ตั้งค่าการอัปโหลดสูงสุด servlet ขอเนื้อหายาว ค่าเริ่มต้นคือ 1024 * 1024 * 100 (Automatic Translation)
 overall-maximum-upload-request-size=ขนาดขออัพโหลดสูงสุดโดยรวม (Automatic Translation)
-temp-dir-help=ตั้งค่าไดเรกทอรีชั่วคราวสำหรับอัปโหลดแฟ้ม (Automatic Translation)
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=ไดเรกทอรีที่เก็บชั่วคราว (Automatic Translation)
 upload-servlet-request-configuration-name=อัปโหลดคำขอ Servlet (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_tr.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Maksimum yükleme servlet isteğini içerik uzunluğu ayarlayın. Varsayılan değer 1024 * 1024 * 100 dür. (Automatic Translation)
 overall-maximum-upload-request-size=Genel olarak maksimum yükleme isteği boyutu (Automatic Translation)
-temp-dir-help=Karşıya yüklenen dosyaları geçici dizini ayarlayın. (Automatic Translation)
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Geçici depolama dizini (Automatic Translation)
 upload-servlet-request-configuration-name=Servlet isteği upload (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_uk.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Визначте максимально завантажити сервлетів запиту вмісту. Значенням за промовчанням є 1024 * 1024 * 100. (Automatic Translation)
 overall-maximum-upload-request-size=В цілому максимум запит розмір для завантаження (Automatic Translation)
-temp-dir-help=Встановити тимчасового каталогу для завантажених файлів. (Automatic Translation)
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Тимчасове сховище каталогу (Automatic Translation)
 upload-servlet-request-configuration-name=Завантажити сервлетів запит (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_vi.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=Thiết lập yêu cầu nội dung servlet tải lên tối đa chiều dài. Mặc định là 1024 * 1024 * 100. (Automatic Translation)
 overall-maximum-upload-request-size=Tổng thể tải lên tối đa yêu cầu kích thước (Automatic Translation)
-temp-dir-help=Thiết lập thư mục tạm thời cho các tập tin được tải lên. (Automatic Translation)
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=Thư mục chứa tạm thời
 upload-servlet-request-configuration-name=Tải lên các Servlet yêu cầu (Automatic Translation)

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_zh_CN.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=设置最大上传Servlet请求内容长度，默认值为1024 * 1024 * 100。
 overall-maximum-upload-request-size=总体最大上传需求大小
-temp-dir-help=设置上传文件的临时目录。
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=临时存储目录
 upload-servlet-request-configuration-name=上传Servlet请求

--- a/modules/apps/portal/portal-upload/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal/portal-upload/src/main/resources/content/Language_zh_TW.properties
@@ -1,5 +1,6 @@
+invalid-temporary-storage-directory-message=Invalid Temporary Storage Directory. Please enter a valid directory. (Automatic Copy)
 max-size-help=設置最大上載 servlet 請求內容的長度。預設值為 1024 * 1024 * 100。 (Automatic Translation)
 overall-maximum-upload-request-size=整體最大上載請求大小 (Automatic Translation)
-temp-dir-help=設置上傳檔的臨時目錄。 (Automatic Translation)
+temp-dir-help=Set the temporary directory for uploaded files. A blank value will set the configuration back to the default value. (Automatic Copy)
 temporary-storage-directory=臨時儲存目錄
 upload-servlet-request-configuration-name=上傳 Servlet 請求 (Automatic Translation)


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-81716

Hey Pei-Jung,

The scope of the LPs is to just be able to reset the temp storage dir back to it's default value if you input a blank string (this is how the configuration initially loads).  I also went a bit further and decided to validate the configuration if it's not null.  If the directory turns out to be invalid, we throw an exception instead of saving it.

Please let me know if you have any questions, thanks!