### PR TITLE
[TECHNICAL SUPPORT] LPS-95378 Do not always convert to array, maintain variable type to String or String[] and add it to the map

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/portlet/action/ExportConfigurationMVCResourceCommand.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/portlet/action/ExportConfigurationMVCResourceCommand.java
@@ -269,15 +269,14 @@ public class ExportConfigurationMVCResourceCommand
 				continue;
 			}
 
-			String[] values = AttributeDefinitionUtil.getProperty(
+			Object value = AttributeDefinitionUtil.getObjectProperty(
 				attributeDefinition, configuration);
 
-			if (values.length == 1) {
-				properties.put(attributeDefinition.getID(), values[0]);
+			if (value == null) {
+				continue;
 			}
-			else if (values.length > 1) {
-				properties.put(attributeDefinition.getID(), values);
-			}
+
+			properties.put(attributeDefinition.getID(), value);
 		}
 
 		return properties;

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/AttributeDefinitionUtil.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/AttributeDefinitionUtil.java
@@ -47,7 +47,7 @@ public class AttributeDefinitionUtil {
 		return StringUtil.split(defaultValues[0], StringPool.PIPE);
 	}
 
-	public static String[] getProperty(
+	public static Object getObjectProperty(
 		AttributeDefinition attributeDefinition, Configuration configuration) {
 
 		Dictionary<String, Object> properties = configuration.getProperties();
@@ -61,7 +61,7 @@ public class AttributeDefinitionUtil {
 		int cardinality = attributeDefinition.getCardinality();
 
 		if (cardinality == 0) {
-			return new String[] {String.valueOf(property)};
+			return String.valueOf(property);
 		}
 
 		if (cardinality > 0) {
@@ -69,12 +69,24 @@ public class AttributeDefinitionUtil {
 				return ArrayUtil.toStringArray((Object[])property);
 			}
 
-			return new String[] {String.valueOf(property)};
+			return String.valueOf(property);
 		}
 
 		Vector<?> vector = (Vector<?>)property;
 
 		return ArrayUtil.toStringArray(vector.toArray());
+	}
+
+	public static String[] getProperty(
+		AttributeDefinition attributeDefinition, Configuration configuration) {
+
+		Object value = getObjectProperty(attributeDefinition, configuration);
+
+		if (value instanceof String[]) {
+			return (String[])value;
+		}
+
+		return new String[] {String.valueOf(value)};
 	}
 
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-95378

Current code of **getProperties** method converts all objects to String[], so later during *.config file generation it is not possible to differenciate between a plain String field from a String array with only one element