### PR TITLE
LPS-97363 The order of Japanese prefectures is incorrect in any area of Liferay that uses dynamically populated addresses

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/RegionServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RegionServiceImpl.java
@@ -14,16 +14,23 @@
 
 package com.liferay.portal.service.impl;
 
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.RegionCodeException;
 import com.liferay.portal.kernel.exception.RegionNameException;
+import com.liferay.portal.kernel.model.Country;
 import com.liferay.portal.kernel.model.Region;
 import com.liferay.portal.kernel.security.access.control.AccessControlled;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.OrderByComparatorFactoryUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.model.impl.RegionModelImpl;
 import com.liferay.portal.service.base.RegionServiceBaseImpl;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author Brian Wing Shun Chan
@@ -98,13 +105,38 @@ public class RegionServiceImpl extends RegionServiceBaseImpl {
 
 	@Override
 	public List<Region> getRegions(long countryId) {
-		return regionPersistence.findByCountryId(countryId);
+		return regionPersistence.findByCountryId(
+			countryId, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+			_getOrderByComparator(countryId));
 	}
 
 	@AccessControlled(guestAccessEnabled = true)
 	@Override
 	public List<Region> getRegions(long countryId, boolean active) {
-		return regionPersistence.findByC_A(countryId, active);
+		return regionPersistence.findByC_A(
+			countryId, active, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+			_getOrderByComparator(countryId));
 	}
+
+	private OrderByComparator<Region> _getOrderByComparator(long countryId) {
+		Country country = countryService.fetchCountry(countryId);
+
+		if (country == null) {
+			return null;
+		}
+
+		return _countryOrderByComparatorMap.get(country.getA2());
+	}
+
+	private static final Map<String, OrderByComparator<Region>>
+		_countryOrderByComparatorMap =
+			new HashMap<String, OrderByComparator<Region>>() {
+				{
+					put(
+						"JP",
+						OrderByComparatorFactoryUtil.create(
+							RegionModelImpl.TABLE_NAME, "regionCode", true));
+				}
+			};
 
 }

--- a/portal-impl/test/integration/com/liferay/region/service/RegionServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/region/service/RegionServiceTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.region.service;
+
+import com.liferay.portal.kernel.model.Country;
+import com.liferay.portal.kernel.model.Region;
+import com.liferay.portal.kernel.service.CountryServiceUtil;
+import com.liferay.portal.kernel.service.RegionServiceUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Drew Brokke
+ */
+public class RegionServiceTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testJapanRegionOrdering() {
+		Country countryJapan = CountryServiceUtil.fetchCountryByA2("JP");
+
+		Assert.assertNotNull(countryJapan);
+
+		long countryId = countryJapan.getCountryId();
+
+		List<Region> sortedRegions = ListUtil.sort(
+			RegionServiceUtil.getRegions(countryId, true),
+			(region1, region2) -> {
+				String regionCode1 = region1.getRegionCode();
+				String regionCode2 = region2.getRegionCode();
+
+				return regionCode1.compareTo(regionCode2);
+			});
+
+		List<Region> unsortedRegions = RegionServiceUtil.getRegions(
+			countryId, true);
+
+		for (int i = 0; i < sortedRegions.size(); i++) {
+			Region region1 = sortedRegions.get(i);
+			Region region2 = unsortedRegions.get(i);
+
+			if (region1.getRegionId() != region2.getRegionId()) {
+				Assert.fail();
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
This is an update for [LPS-97363](https://issues.liferay.com/browse/LPS-97363).<br><br>Hey @pei-jung, will you please double-check my work on this one?  Thanks\!