### PR TITLE
[TECHNICAL-SUPPORT] LPS-100313 Only allow accessing 'edit_user' from the My Account Portlet

### DIFF
--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/MyAccountPortlet.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/MyAccountPortlet.java
@@ -16,9 +16,16 @@ package com.liferay.users.admin.web.internal.portlet;
 
 import com.liferay.portal.kernel.model.Release;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.users.admin.constants.UsersAdminPortletKeys;
 
+import java.io.IOException;
+
 import javax.portlet.Portlet;
+import javax.portlet.PortletException;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -50,6 +57,25 @@ import org.osgi.service.component.annotations.Reference;
 	service = Portlet.class
 )
 public class MyAccountPortlet extends MVCPortlet {
+
+	@Override
+	protected void doDispatch(
+			RenderRequest renderRequest, RenderResponse renderResponse)
+		throws IOException, PortletException {
+
+		String path = getPath(renderRequest, renderResponse);
+
+		if (!path.equals("/edit_user.jsp")) {
+			SessionErrors.add(renderRequest, PrincipalException.class);
+
+			path = "/error.jsp";
+
+			include(path, renderRequest, renderResponse);
+		}
+		else {
+			super.doDispatch(renderRequest, renderResponse);
+		}
+	}
 
 	@Reference(
 		target = "(&(release.bundle.symbolic.name=com.liferay.users.admin.web)(&(release.schema.version>=1.0.1)(!(release.schema.version>=1.1.0))))",


### PR DESCRIPTION
Hello @pei-jung,

The issue is that a user can craft a URL to access the list of users through the My Account Portlet. On Master, the users are filtered so that not all of them are listed but on 7.0.x this filtering does not take place so it exposes the entire list of users.

Even though the vulnerability doesn't display in Master perse, I thought it would be best to lock this portlet down in case a new JSP is added under Users Admin that assumes the user has permission. As far as I could tell the only path My Account Portlet needs access to is `edit_user` but I could be overlooking something.

If you don't think this is the right fix and you'd rather backport whatever change occurred in Master to 7.0.x that is fine as well. This is a critical issue for a client so I wanted to get some fix in front of your team as quickly as possible.

Please let me know if you have any questions.