### PR TITLE
LPS-103362 Avoids scroll in personal menu dropdown

### DIFF
--- a/modules/apps/app-builder/app-builder-web/package.json
+++ b/modules/apps/app-builder/app-builder-web/package.json
@@ -2,7 +2,7 @@
 	"dependencies": {
 		"@clayui/button": "3.0.1",
 		"@clayui/data-provider": "3.0.1",
-		"@clayui/drop-down": "3.0.1",
+		"@clayui/drop-down": "3.1.0",
 		"@clayui/form": "3.1.0",
 		"@clayui/icon": "3.0.1",
 		"@clayui/label": "3.0.1",

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
@@ -11,7 +11,7 @@
 		"@clayui/css": "3.1.0",
 		"@clayui/data-provider": "3.0.1",
 		"@clayui/date-picker": "3.0.1",
-		"@clayui/drop-down": "3.0.1",
+		"@clayui/drop-down": "3.1.0",
 		"@clayui/form": "3.1.0",
 		"@clayui/icon": "3.0.1",
 		"@clayui/label": "3.0.1",

--- a/modules/apps/journal/journal-web/package.json
+++ b/modules/apps/journal/journal-web/package.json
@@ -1,7 +1,7 @@
 {
 	"dependencies": {
 		"@clayui/button": "3.0.1",
-		"@clayui/drop-down": "3.0.1",
+		"@clayui/drop-down": "3.1.0",
 		"@clayui/icon": "3.0.1",
 		"@clayui/label": "3.0.1",
 		"clay-dropdown": "2.18.4",

--- a/modules/apps/layout/layout-content-page-editor-web/package.json
+++ b/modules/apps/layout/layout-content-page-editor-web/package.json
@@ -2,7 +2,7 @@
 	"dependencies": {
 		"@clayui/alert": "3.0.0",
 		"@clayui/button": "3.0.1",
-		"@clayui/drop-down": "3.0.1",
+		"@clayui/drop-down": "3.1.0",
 		"@clayui/form": "3.1.0",
 		"@clayui/icon": "3.0.1",
 		"@clayui/label": "3.0.1",

--- a/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/java/com/liferay/product/navigation/personal/menu/web/internal/portlet/action/GetPersonalMenuItemsMVCResourceCommand.java
+++ b/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/java/com/liferay/product/navigation/personal/menu/web/internal/portlet/action/GetPersonalMenuItemsMVCResourceCommand.java
@@ -215,9 +215,7 @@ public class GetPersonalMenuItemsMVCResourceCommand
 		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		JSONObject dividerJSONObject = JSONFactoryUtil.createJSONObject();
-
-		dividerJSONObject.put("type", "divider");
+		JSONObject dividerJSONObject = JSONUtil.put("type", "divider");
 
 		if (themeDisplay.isImpersonated()) {
 			JSONObject impersonationJSONObject = JSONUtil.put(
@@ -236,28 +234,30 @@ public class GetPersonalMenuItemsMVCResourceCommand
 			);
 
 			jsonArray.put(impersonationJSONObject);
-			jsonArray.put(dividerJSONObject);
 		}
 
-		for (int i = 0; i < groupedPersonalMenuEntries.size(); i++) {
+		for (List<PersonalMenuEntry> groupedPersonalMenuEntry :
+				groupedPersonalMenuEntries) {
+
 			JSONArray personalMenuEntriesJSONArray =
 				_getPersonalMenuEntriesJSONArray(
-					portletRequest, groupedPersonalMenuEntries.get(i));
+					portletRequest, groupedPersonalMenuEntry);
 
 			if (personalMenuEntriesJSONArray.length() == 0) {
 				continue;
 			}
 
-			JSONObject jsonObject = JSONUtil.put(
-				"items", personalMenuEntriesJSONArray);
-
-			jsonObject.put("type", "group");
-
-			jsonArray.put(jsonObject);
-
-			if (i < (groupedPersonalMenuEntries.size() - 1)) {
+			if (jsonArray.length() > 0) {
 				jsonArray.put(dividerJSONObject);
 			}
+
+			JSONObject jsonObject = JSONUtil.put(
+				"items", personalMenuEntriesJSONArray
+			).put(
+				"type", "group"
+			);
+
+			jsonArray.put(jsonObject);
 		}
 
 		if ((jsonArray.length() > 0) && !themeDisplay.isImpersonated()) {

--- a/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/java/com/liferay/product/navigation/personal/menu/web/internal/portlet/action/GetPersonalMenuItemsMVCResourceCommand.java
+++ b/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/java/com/liferay/product/navigation/personal/menu/web/internal/portlet/action/GetPersonalMenuItemsMVCResourceCommand.java
@@ -95,7 +95,7 @@ public class GetPersonalMenuItemsMVCResourceCommand
 			_http.removeParameter(
 				ParamUtil.getString(portletRequest, "currentURL"), "doAsUserId")
 		).put(
-			"icon", "change"
+			"symbolRight", "change"
 		).put(
 			"label",
 			LanguageUtil.get(themeDisplay.getLocale(), "be-yourself-again")
@@ -147,7 +147,7 @@ public class GetPersonalMenuItemsMVCResourceCommand
 					ParamUtil.getString(portletRequest, "currentURL"),
 					"doAsUserLanguageId", doAsUserLanguageId)
 			).put(
-				"icon", "globe"
+				"symbolRight", "globe"
 			).put(
 				"label", changeLanguageLabel
 			);
@@ -192,9 +192,9 @@ public class GetPersonalMenuItemsMVCResourceCommand
 			}
 
 			jsonObject.put(
-				"icon", personalMenuEntry.getIcon(portletRequest)
-			).put(
 				"label", personalMenuEntry.getLabel(themeDisplay.getLocale())
+			).put(
+				"symbolRight", personalMenuEntry.getIcon(portletRequest)
 			);
 
 			jsonArray.put(jsonObject);
@@ -215,7 +215,11 @@ public class GetPersonalMenuItemsMVCResourceCommand
 		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		JSONObject dividerJSONObject = JSONUtil.put("type", "divider");
+		JSONObject dividerJSONObject = JSONUtil.put(
+			"type", "divider"
+		).put(
+			"symbolRight", "divider"
+		);
 
 		if (themeDisplay.isImpersonated()) {
 			JSONObject impersonationJSONObject = JSONUtil.put(

--- a/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/java/com/liferay/product/navigation/personal/menu/web/internal/portlet/action/GetPersonalMenuItemsMVCResourceCommand.java
+++ b/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/java/com/liferay/product/navigation/personal/menu/web/internal/portlet/action/GetPersonalMenuItemsMVCResourceCommand.java
@@ -215,11 +215,7 @@ public class GetPersonalMenuItemsMVCResourceCommand
 		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		JSONObject dividerJSONObject = JSONUtil.put(
-			"type", "divider"
-		).put(
-			"symbolRight", "divider"
-		);
+		JSONObject dividerJSONObject = JSONUtil.put("type", "divider");
 
 		if (themeDisplay.isImpersonated()) {
 			JSONObject impersonationJSONObject = JSONUtil.put(

--- a/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/java/com/liferay/product/navigation/personal/menu/web/internal/portlet/action/GetPersonalMenuItemsMVCResourceCommand.java
+++ b/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/java/com/liferay/product/navigation/personal/menu/web/internal/portlet/action/GetPersonalMenuItemsMVCResourceCommand.java
@@ -215,6 +215,10 @@ public class GetPersonalMenuItemsMVCResourceCommand
 		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
+		JSONObject dividerJSONObject = JSONFactoryUtil.createJSONObject();
+
+		dividerJSONObject.put("type", "divider");
+
 		if (themeDisplay.isImpersonated()) {
 			JSONObject impersonationJSONObject = JSONUtil.put(
 				"items",
@@ -228,12 +232,11 @@ public class GetPersonalMenuItemsMVCResourceCommand
 					user.getFullName(),
 					LanguageUtil.get(themeDisplay.getLocale(), "impersonated"))
 			).put(
-				"separator", true
-			).put(
 				"type", "group"
 			);
 
 			jsonArray.put(impersonationJSONObject);
+			jsonArray.put(dividerJSONObject);
 		}
 
 		for (int i = 0; i < groupedPersonalMenuEntries.size(); i++) {
@@ -248,13 +251,13 @@ public class GetPersonalMenuItemsMVCResourceCommand
 			JSONObject jsonObject = JSONUtil.put(
 				"items", personalMenuEntriesJSONArray);
 
-			if (i < (groupedPersonalMenuEntries.size() - 1)) {
-				jsonObject.put("separator", true);
-			}
-
 			jsonObject.put("type", "group");
 
 			jsonArray.put(jsonObject);
+
+			if (i < (groupedPersonalMenuEntries.size() - 1)) {
+				jsonArray.put(dividerJSONObject);
+			}
 		}
 
 		if ((jsonArray.length() > 0) && !themeDisplay.isImpersonated()) {

--- a/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/resources/META-INF/resources/control_menu/personal_menu_icon.jsp
+++ b/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/resources/META-INF/resources/control_menu/personal_menu_icon.jsp
@@ -27,6 +27,7 @@
 
 	#impersonate-user-sticker {
 		bottom: -.4rem;
+		color: #000;
 		font-size: .6rem;
 		height: 1.2rem;
 		right: -0.4rem;
@@ -40,27 +41,9 @@
 
 <li class="control-menu-nav-item">
 	<span class="user-avatar-link">
-		<liferay-util:buffer
-			var="userAvatar"
-		>
-			<span class="sticker">
-				<span class="inline-item" id="personal-menu-icon-wrapper">
-					<liferay-ui:user-portrait
-						user="<%= user %>"
-					/>
-				</span>
-
-				<c:if test="<%= themeDisplay.isImpersonated() %>">
-					<span class="sticker sticker-bottom-right sticker-circle sticker-outside sticker-user-icon" id="impersonate-user-sticker">
-						<aui:icon id="impersonate-user-icon" image="user" markupView="lexicon" />
-					</span>
-				</c:if>
-			</span>
-		</liferay-util:buffer>
-
 		<liferay-product-navigation:personal-menu
 			expanded="<%= true %>"
-			label="<%= userAvatar %>"
+			user="<%= user %>"
 		/>
 
 		<%

--- a/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/resources/META-INF/resources/init.jsp
@@ -20,9 +20,7 @@
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
 taglib uri="http://liferay.com/tld/product-navigation" prefix="liferay-product-navigation" %><%@
-taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
-taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
-taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 
 <%@ page import="com.liferay.portal.kernel.model.UserNotificationEvent" %><%@
 page import="com.liferay.portal.kernel.portlet.PortletProvider" %><%@

--- a/modules/apps/product-navigation/product-navigation-taglib/.babelrc
+++ b/modules/apps/product-navigation/product-navigation-taglib/.babelrc
@@ -1,0 +1,5 @@
+{
+	"presets": [
+		"@babel/preset-react"
+	]
+}

--- a/modules/apps/product-navigation/product-navigation-taglib/.eslintrc.js
+++ b/modules/apps/product-navigation/product-navigation-taglib/.eslintrc.js
@@ -1,4 +1,3 @@
-<%--
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
  *
@@ -12,12 +11,7 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
---%>
 
-<%@ include file="/init.jsp" %>
-
-<%@ page import="com.liferay.product.navigation.control.menu.constants.ProductNavigationControlMenuCategoryKeys" %><%@
-page import="com.liferay.product.navigation.control.menu.util.ProductNavigationControlMenuCategoryRegistry" %><%@
-page import="com.liferay.product.navigation.taglib.internal.servlet.ServletContextUtil" %>
-
-<%@ page import="java.util.LinkedHashMap" %>
+module.exports = {
+	extends: ['liferay/react']
+};

--- a/modules/apps/product-navigation/product-navigation-taglib/.npmbundlerrc
+++ b/modules/apps/product-navigation/product-navigation-taglib/.npmbundlerrc
@@ -1,5 +1,6 @@
 {
     "ignore": [
-        "**/*"
+        "**/config.js",
+        "**/control_menu/**/*"
     ]
 }

--- a/modules/apps/product-navigation/product-navigation-taglib/build.gradle
+++ b/modules/apps/product-navigation/product-navigation-taglib/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
 	compileOnly project(":apps:product-navigation:product-navigation-control-menu-api")
 	compileOnly project(":apps:product-navigation:product-navigation-personal-menu-api")
 	compileOnly project(":core:petra:petra-lang")

--- a/modules/apps/product-navigation/product-navigation-taglib/package.json
+++ b/modules/apps/product-navigation/product-navigation-taglib/package.json
@@ -1,9 +1,9 @@
 {
 	"dependencies": {
-		"@clayui/button": "3.0.0",
-		"@clayui/drop-down": "3.0.0",
-		"@clayui/icon": "3.0.0",
-		"@clayui/sticker": "3.0.0",
+		"@clayui/button": "3.0.1",
+		"@clayui/drop-down": "3.1.0",
+		"@clayui/icon": "3.0.1",
+		"@clayui/sticker": "3.0.1",
 		"frontend-js-web": "*",
 		"prop-types": "15.7.2",
 		"react": "16.9.0"

--- a/modules/apps/product-navigation/product-navigation-taglib/package.json
+++ b/modules/apps/product-navigation/product-navigation-taglib/package.json
@@ -1,4 +1,13 @@
 {
+	"dependencies": {
+		"@clayui/button": "3.0.0",
+		"@clayui/drop-down": "3.0.0",
+		"@clayui/icon": "3.0.0",
+		"@clayui/sticker": "3.0.0",
+		"frontend-js-web": "*",
+		"prop-types": "15.7.2",
+		"react": "16.9.0"
+	},
 	"name": "product-navigation-taglib",
 	"scripts": {
 		"build": "liferay-npm-scripts build",

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/java/com/liferay/product/navigation/taglib/servlet/taglib/ProductNavigationPersonalMenuTag.java
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/java/com/liferay/product/navigation/taglib/servlet/taglib/ProductNavigationPersonalMenuTag.java
@@ -14,6 +14,7 @@
 
 package com.liferay.product.navigation.taglib.servlet.taglib;
 
+import com.liferay.portal.kernel.model.User;
 import com.liferay.product.navigation.taglib.internal.servlet.ServletContextUtil;
 import com.liferay.taglib.util.IncludeTag;
 
@@ -27,6 +28,14 @@ public class ProductNavigationPersonalMenuTag extends IncludeTag {
 
 	public String getLabel() {
 		return _label;
+	}
+
+	public String getSize() {
+		return _size;
+	}
+
+	public User getUSer() {
+		return _user;
 	}
 
 	public boolean isExpanded() {
@@ -48,12 +57,22 @@ public class ProductNavigationPersonalMenuTag extends IncludeTag {
 		setServletContext(ServletContextUtil.getServletContext());
 	}
 
+	public void setSize(String size) {
+		_size = size;
+	}
+
+	public void setUser(User user) {
+		_user = user;
+	}
+
 	@Override
 	protected void cleanUp() {
 		super.cleanUp();
 
 		_expanded = false;
 		_label = null;
+		_size = null;
+		_user = null;
 	}
 
 	@Override
@@ -63,15 +82,27 @@ public class ProductNavigationPersonalMenuTag extends IncludeTag {
 
 	@Override
 	protected void setAttributes(HttpServletRequest httpServletRequest) {
+		long color = 0;
+
+		if (_user != null) {
+			color = _user.getUserId() % 10;
+		}
+
+		httpServletRequest.setAttribute(
+			"liferay-product-navigation:personal-menu:color", color);
 		httpServletRequest.setAttribute(
 			"liferay-product-navigation:personal-menu:expanded", _expanded);
 		httpServletRequest.setAttribute(
 			"liferay-product-navigation:personal-menu:label", _label);
+		httpServletRequest.setAttribute(
+			"liferay-product-navigation:personal-menu:size", _size);
 	}
 
 	private static final String _PAGE = "/personal_menu/page.jsp";
 
 	private boolean _expanded;
 	private String _label;
+	private String _size;
+	private User _user;
 
 }

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/liferay-product-navigation.tld
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/liferay-product-navigation.tld
@@ -33,5 +33,17 @@
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
+		<attribute>
+			<description></description>
+			<name>size</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>user</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
 	</tag>
 </taglib>

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/init.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
@@ -27,6 +28,8 @@ page import="com.liferay.product.navigation.control.menu.ProductNavigationContro
 page import="com.liferay.product.navigation.control.menu.util.ProductNavigationControlMenuEntryRegistry" %><%@
 page import="com.liferay.taglib.servlet.PipingServletResponse" %>
 
-<%@ page import="java.util.List" %>
+<%@ page import="java.util.HashMap" %><%@
+page import="java.util.List" %><%@
+page import="java.util.Map" %>
 
 <liferay-theme:defineObjects />

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/init.jsp
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/init.jsp
@@ -19,6 +19,7 @@
 <%@ page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.portlet.PortletURLFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.util.StringUtil" %><%@
+page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.product.navigation.personal.menu.constants.PersonalMenuPortletKeys" %>
 
 <%@ page import="javax.portlet.PortletRequest" %><%@

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/js/PersonalMenu.es.js
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/js/PersonalMenu.es.js
@@ -20,7 +20,7 @@ import {fetch} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useState, useRef} from 'react';
 
-function PersonalMenu({itemsURL}) {
+function PersonalMenu({color, isImpersonated, itemsURL, size}) {
 	const [items, setItems] = useState([]);
 	const preloadPromise = useRef();
 
@@ -41,13 +41,30 @@ function PersonalMenu({itemsURL}) {
 					onFocus={preloadItems}
 					onMouseOver={preloadItems}
 				>
-					<ClaySticker
-						className="user-icon-color-4"
-						shape="circle"
-						size="lg"
-					>
-						<ClayIcon symbol="user" />
-					</ClaySticker>
+					<span className={`sticker sticker-${size}`}>
+						<ClaySticker
+							className={`user-icon-color-${color}`}
+							shape="circle"
+							size={size}
+						>
+							<ClayIcon symbol="user" />
+						</ClaySticker>
+
+						{isImpersonated && (
+							<ClaySticker
+								className="sticker-user-icon"
+								id="impersonate-user-sticker"
+								outside
+								position="bottom-right"
+								shape="circle"
+								size={size ? 'sm' : ''}
+							>
+								<span id="impersonate-user-icon">
+									<ClayIcon symbol="user" />
+								</span>
+							</ClaySticker>
+						)}
+					</span>
 				</ClayButton>
 			}
 		/>

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/js/PersonalMenu.es.js
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/js/PersonalMenu.es.js
@@ -13,18 +13,16 @@
  */
 
 import ClayButton from '@clayui/button';
-import {Align, ClayDropDownWithItems} from '@clayui/drop-down';
+import {ClayDropDownWithItems} from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import ClaySticker from '@clayui/sticker';
 import {fetch} from 'frontend-js-web';
 import PropTypes from 'prop-types';
-import React, {createRef, useState} from 'react';
-
-const preloadPromise = createRef();
+import React, {useState, useRef} from 'react';
 
 function PersonalMenu({itemsURL}) {
-	const [active, setActive] = useState(false);
 	const [items, setItems] = useState([]);
+	const preloadPromise = useRef();
 
 	function preloadItems() {
 		if (!preloadPromise.current) {
@@ -32,26 +30,16 @@ function PersonalMenu({itemsURL}) {
 				.then(response => response.json())
 				.then(items => setItems(items));
 		}
-
-		return preloadPromise.current;
-	}
-
-	function toggleActive(newVal) {
-		preloadItems().then(setActive(newVal));
 	}
 
 	return (
 		<ClayDropDownWithItems
-			active={active}
-			alignmentPosition={Align.BottomRight}
 			items={items}
-			onActiveChange={toggleActive}
 			trigger={
 				<ClayButton
 					displayType="unstyled"
 					onFocus={preloadItems}
 					onMouseOver={preloadItems}
-					symbol="user"
 				>
 					<ClaySticker
 						className="user-icon-color-4"

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/js/PersonalMenu.es.js
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/js/PersonalMenu.es.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import ClayButton from '@clayui/button';
+import {Align, ClayDropDownWithItems} from '@clayui/drop-down';
+import ClayIcon from '@clayui/icon';
+import ClaySticker from '@clayui/sticker';
+import {fetch} from 'frontend-js-web';
+import PropTypes from 'prop-types';
+import React, {createRef, useState} from 'react';
+
+const preloadPromise = createRef();
+
+function PersonalMenu({itemsURL}) {
+	const [active, setActive] = useState(false);
+	const [items, setItems] = useState([]);
+
+	function preloadItems() {
+		if (!preloadPromise.current) {
+			preloadPromise.current = fetch(itemsURL)
+				.then(response => response.json())
+				.then(items => setItems(items));
+		}
+
+		return preloadPromise.current;
+	}
+
+	function toggleActive(newVal) {
+		preloadItems().then(setActive(newVal));
+	}
+
+	return (
+		<ClayDropDownWithItems
+			active={active}
+			alignmentPosition={Align.BottomRight}
+			items={items}
+			onActiveChange={toggleActive}
+			trigger={
+				<ClayButton
+					displayType="unstyled"
+					onFocus={preloadItems}
+					onMouseOver={preloadItems}
+					symbol="user"
+				>
+					<ClaySticker
+						className="user-icon-color-4"
+						shape="circle"
+						size="lg"
+					>
+						<ClayIcon symbol="user" />
+					</ClaySticker>
+				</ClayButton>
+			}
+		/>
+	);
+}
+
+PersonalMenu.propTypes = {
+	itemsURL: PropTypes.string
+};
+
+export default function(props) {
+	return <PersonalMenu {...props} />;
+}

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/js/PersonalMenu.es.js
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/js/PersonalMenu.es.js
@@ -37,7 +37,11 @@ function PersonalMenu({color, isImpersonated, itemsURL, label, size}) {
 			items={items}
 			trigger={
 				label ? (
-					<div dangerouslySetInnerHTML={{__html: label}} />
+					<div
+						onFocus={preloadItems}
+						onMouseOver={preloadItems}
+						dangerouslySetInnerHTML={{__html: label}}
+					/>
 				) : (
 					<ClayButton
 						displayType="unstyled"

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/js/PersonalMenu.es.js
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/js/PersonalMenu.es.js
@@ -20,7 +20,7 @@ import {fetch} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useState, useRef} from 'react';
 
-function PersonalMenu({color, isImpersonated, itemsURL, size}) {
+function PersonalMenu({color, isImpersonated, itemsURL, label, size}) {
 	const [items, setItems] = useState([]);
 	const preloadPromise = useRef();
 
@@ -36,36 +36,40 @@ function PersonalMenu({color, isImpersonated, itemsURL, size}) {
 		<ClayDropDownWithItems
 			items={items}
 			trigger={
-				<ClayButton
-					displayType="unstyled"
-					onFocus={preloadItems}
-					onMouseOver={preloadItems}
-				>
-					<span className={`sticker sticker-${size}`}>
-						<ClaySticker
-							className={`user-icon-color-${color}`}
-							shape="circle"
-							size={size}
-						>
-							<ClayIcon symbol="user" />
-						</ClaySticker>
-
-						{isImpersonated && (
+				label ? (
+					<div dangerouslySetInnerHTML={{__html: label}} />
+				) : (
+					<ClayButton
+						displayType="unstyled"
+						onFocus={preloadItems}
+						onMouseOver={preloadItems}
+					>
+						<span className={`sticker sticker-${size}`}>
 							<ClaySticker
-								className="sticker-user-icon"
-								id="impersonate-user-sticker"
-								outside
-								position="bottom-right"
+								className={`user-icon-color-${color}`}
 								shape="circle"
-								size={size ? 'sm' : ''}
+								size={size}
 							>
-								<span id="impersonate-user-icon">
-									<ClayIcon symbol="user" />
-								</span>
+								<ClayIcon symbol="user" />
 							</ClaySticker>
-						)}
-					</span>
-				</ClayButton>
+
+							{isImpersonated && (
+								<ClaySticker
+									className="sticker-user-icon"
+									id="impersonate-user-sticker"
+									outside
+									position="bottom-right"
+									shape="circle"
+									size={size ? 'sm' : ''}
+								>
+									<span id="impersonate-user-icon">
+										<ClayIcon symbol="user" />
+									</span>
+								</ClaySticker>
+							)}
+						</span>
+					</ClayButton>
+				)
 			}
 		/>
 	);

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/js/PersonalMenu.es.js
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/js/PersonalMenu.es.js
@@ -35,6 +35,7 @@ function PersonalMenu({color, isImpersonated, itemsURL, label, size}) {
 	return (
 		<ClayDropDownWithItems
 			items={items}
+			menuElementAttrs={{className: 'dropdown-menu-personal-menu'}}
 			trigger={
 				label ? (
 					<div

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/page.jsp
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/page.jsp
@@ -45,104 +45,21 @@ String label = (String)request.getAttribute("liferay-product-navigation:personal
 	<button aria-expanded="true" aria-haspopup="true" class="btn btn-unstyled dropdown-toggle" id="<%= namespace + "personal_menu_dropdown_toggle" %>" ref="triggerButton" type="button">
 		<%= label %>
 	</button>
+
+	<%
+	ResourceURL resourceURL = PortletURLFactoryUtil.create(request, PersonalMenuPortletKeys.PERSONAL_MENU, PortletRequest.RESOURCE_PHASE);
+
+	resourceURL.setParameter("currentURL", themeDisplay.getURLCurrent());
+	resourceURL.setParameter("portletId", themeDisplay.getPpid());
+	resourceURL.setResourceID("/get_personal_menu_items");
+
+	Map<String, Object> data = new HashMap<>();
+
+	data.put("itemsURL", resourceURL.toString());
+	%>
+
+	<react:component
+		data="<%= data %>"
+		module="personal_menu/js/PersonalMenu.es"
+	/>
 </div>
-
-<%
-ResourceURL resourceURL = PortletURLFactoryUtil.create(request, PersonalMenuPortletKeys.PERSONAL_MENU, PortletRequest.RESOURCE_PHASE);
-
-resourceURL.setParameter("currentURL", themeDisplay.getURLCurrent());
-resourceURL.setParameter("portletId", themeDisplay.getPpid());
-resourceURL.setResourceID("/get_personal_menu_items");
-%>
-
-<aui:script require="clay-dropdown/src/ClayDropdown as ClayDropdown,metal-dom/src/dom as dom, metal-position/src/Position">
-	var toggle = document.getElementById(
-		'<%= namespace + "personal_menu_dropdown_toggle" %>'
-	);
-
-	if (toggle) {
-		dom.once(toggle, 'click', function(event) {
-			Liferay.Util.fetch('<%= resourceURL.toString() %>', {
-				method: 'GET'
-			})
-				.then(function(response) {
-					return response.json();
-				})
-				.then(function(personalMenuItems) {
-					var personalMenu = new ClayDropdown.default(
-						{
-							element:
-								'#<%= namespace + "personal_menu_dropdown_toggle" %>',
-							events: {
-								willAttach: function(event) {
-									if (<%= expanded %>) {
-										this.expanded = true;
-									}
-
-									var toggleButton = this.element.querySelector(
-										'button'
-									);
-
-									toggleButton.focus();
-
-									var dropdown = this;
-
-									this.refs.dropdown.refs.portal.on(
-										'menuExpanded',
-										function(event) {
-											var Position =
-												metalPositionSrcPosition.default;
-
-											var menu = this.element;
-											var menuRegion = Position.getRegion(
-												menu
-											);
-
-											if (menuRegion.top < 0) {
-												var body = document.querySelector(
-													'body'
-												);
-												var bodyRegion = Position.getRegion(
-													body
-												);
-
-												menu.style.top =
-													bodyRegion.top + 'px';
-											}
-										}
-									);
-
-									this.refs.dropdown.refs.portal.on(
-										'rendered',
-										function(event) {
-											if (dropdown.expanded) {
-												this.element.classList.add(
-													'dropdown-menu-personal-menu'
-												);
-												this.element.classList.remove(
-													'dropdown-menu-indicator-start'
-												);
-
-												this.emit('menuExpanded', event);
-											}
-										}
-									);
-								}
-							},
-							items: personalMenuItems,
-							itemsIconAlignment: 'right',
-							label: toggle.innerHTML,
-							showToggleIcon: false,
-							spritemap:
-								'<%= themeDisplay.getPathThemeImages().concat("/clay/icons.svg") %>'
-						},
-						'#<%= namespace + "personal_menu_dropdown" %>'
-					);
-
-					Liferay.once('beforeNavigate', function(event) {
-						personalMenu.refs.dropdown.refs.portal.detach();
-					});
-				});
-		});
-	}
-</aui:script>

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/page.jsp
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/page.jsp
@@ -19,8 +19,21 @@
 <%
 String namespace = StringUtil.randomId() + StringPool.UNDERLINE;
 
+long color = (long)request.getAttribute("liferay-product-navigation:personal-menu:color");
 boolean expanded = (boolean)request.getAttribute("liferay-product-navigation:personal-menu:expanded");
-String label = (String)request.getAttribute("liferay-product-navigation:personal-menu:label");
+String size = (String)request.getAttribute("liferay-product-navigation:personal-menu:size");
+
+String userStickerClasses = "sticker";
+
+if (size != null) {
+	userStickerClasses += " sticker-" + size;
+}
+
+String impersonateStickerClasses = "sticker";
+
+if (size != null) {
+	impersonateStickerClasses += " sticker-sm";
+}
 %>
 
 <style type="text/css">
@@ -43,7 +56,19 @@ String label = (String)request.getAttribute("liferay-product-navigation:personal
 
 <div class="personal-menu-dropdown" id="<%= namespace + "personal_menu_dropdown" %>">
 	<button aria-expanded="true" aria-haspopup="true" class="btn btn-unstyled dropdown-toggle" id="<%= namespace + "personal_menu_dropdown_toggle" %>" ref="triggerButton" type="button">
-		<%= label %>
+		<span class="<%= userStickerClasses %>">
+			<span class="<%= userStickerClasses + " sticker-circle user-icon-color-" + color %>">
+				<aui:icon image="user" markupView="lexicon" />
+			</span>
+
+			<c:if test="<%= themeDisplay.isImpersonated() %>">
+				<span class='<%= impersonateStickerClasses + " sticker-bottom-right sticker-circle sticker-outside sticker-user-icon" %>' id="impersonate-user-sticker">
+					<span class="sticker-overlay">
+						<aui:icon id="impersonate-user-icon" image="user" markupView="lexicon" />
+					</span>
+				</span>
+			</c:if>
+		</span>
 	</button>
 
 	<%
@@ -55,7 +80,10 @@ String label = (String)request.getAttribute("liferay-product-navigation:personal
 
 	Map<String, Object> data = new HashMap<>();
 
+	data.put("color", color);
+	data.put("isImpersonated", themeDisplay.isImpersonated());
 	data.put("itemsURL", resourceURL.toString());
+	data.put("size", size);
 	%>
 
 	<react:component

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/page.jsp
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/page.jsp
@@ -21,7 +21,7 @@ String namespace = StringUtil.randomId() + StringPool.UNDERLINE;
 
 long color = (long)request.getAttribute("liferay-product-navigation:personal-menu:color");
 boolean expanded = (boolean)request.getAttribute("liferay-product-navigation:personal-menu:expanded");
-boolean label = (boolean)request.getAttribute("liferay-product-navigation:personal-menu:label");
+String label = (String)request.getAttribute("liferay-product-navigation:personal-menu:label");
 String size = (String)request.getAttribute("liferay-product-navigation:personal-menu:size");
 
 String userStickerClasses = "sticker";
@@ -58,7 +58,7 @@ if (size != null) {
 <div class="personal-menu-dropdown" id="<%= namespace + "personal_menu_dropdown" %>">
 	<c:choose>
 		<c:when test="<%= Validator.isNotNull(label) %>">
-			<%= label %>
+			<div><%= label %></div>
 		</c:when>
 		<c:otherwise>
 			<button aria-expanded="true" aria-haspopup="true" class="btn btn-unstyled dropdown-toggle" id="<%= namespace + "personal_menu_dropdown_toggle" %>" ref="triggerButton" type="button">

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/page.jsp
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/page.jsp
@@ -38,11 +38,11 @@ if (size != null) {
 %>
 
 <style type="text/css">
-	#clay_dropdown_portal .dropdown-menu-personal-menu {
+	.dropdown-menu-personal-menu {
 		max-height: none;
 	}
 
-	#clay_dropdown_portal .dropdown-menu-personal-menu .dropdown-item-indicator {
+	.dropdown-menu-personal-menu .dropdown-item-indicator {
 		padding-right: 0.5rem;
 	}
 

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/page.jsp
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/page.jsp
@@ -21,6 +21,7 @@ String namespace = StringUtil.randomId() + StringPool.UNDERLINE;
 
 long color = (long)request.getAttribute("liferay-product-navigation:personal-menu:color");
 boolean expanded = (boolean)request.getAttribute("liferay-product-navigation:personal-menu:expanded");
+boolean label = (boolean)request.getAttribute("liferay-product-navigation:personal-menu:label");
 String size = (String)request.getAttribute("liferay-product-navigation:personal-menu:size");
 
 String userStickerClasses = "sticker";
@@ -55,21 +56,28 @@ if (size != null) {
 </style>
 
 <div class="personal-menu-dropdown" id="<%= namespace + "personal_menu_dropdown" %>">
-	<button aria-expanded="true" aria-haspopup="true" class="btn btn-unstyled dropdown-toggle" id="<%= namespace + "personal_menu_dropdown_toggle" %>" ref="triggerButton" type="button">
-		<span class="<%= userStickerClasses %>">
-			<span class="<%= userStickerClasses + " sticker-circle user-icon-color-" + color %>">
-				<aui:icon image="user" markupView="lexicon" />
-			</span>
-
-			<c:if test="<%= themeDisplay.isImpersonated() %>">
-				<span class='<%= impersonateStickerClasses + " sticker-bottom-right sticker-circle sticker-outside sticker-user-icon" %>' id="impersonate-user-sticker">
-					<span class="sticker-overlay">
-						<aui:icon id="impersonate-user-icon" image="user" markupView="lexicon" />
+	<c:choose>
+		<c:when test="<%= Validator.isNotNull(label) %>">
+			<%= label %>
+		</c:when>
+		<c:otherwise>
+			<button aria-expanded="true" aria-haspopup="true" class="btn btn-unstyled dropdown-toggle" id="<%= namespace + "personal_menu_dropdown_toggle" %>" ref="triggerButton" type="button">
+				<span class="<%= userStickerClasses %>">
+					<span class="<%= userStickerClasses + " sticker-circle user-icon-color-" + color %>">
+						<aui:icon image="user" markupView="lexicon" />
 					</span>
+
+					<c:if test="<%= themeDisplay.isImpersonated() %>">
+						<span class='<%= impersonateStickerClasses + " sticker-bottom-right sticker-circle sticker-outside sticker-user-icon" %>' id="impersonate-user-sticker">
+							<span class="sticker-overlay">
+								<aui:icon id="impersonate-user-icon" image="user" markupView="lexicon" />
+							</span>
+						</span>
+					</c:if>
 				</span>
-			</c:if>
-		</span>
-	</button>
+			</button>
+		</c:otherwise>
+	</c:choose>
 
 	<%
 	ResourceURL resourceURL = PortletURLFactoryUtil.create(request, PersonalMenuPortletKeys.PERSONAL_MENU, PortletRequest.RESOURCE_PHASE);
@@ -83,6 +91,7 @@ if (size != null) {
 	data.put("color", color);
 	data.put("isImpersonated", themeDisplay.isImpersonated());
 	data.put("itemsURL", resourceURL.toString());
+	data.put("label", label);
 	data.put("size", size);
 	%>
 

--- a/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/resources/META-INF/resources/css/main.scss
@@ -9,11 +9,11 @@
 			right: -0.5rem;
 		}
 
-		.sticker-lg .lexicon-icon {
+		.sticker-lg .inline-item .lexicon-icon {
 			margin-top: -0.25rem;
 		}
 
-		.sticker-sm .lexicon-icon {
+		.sticker-sm .inline-item .lexicon-icon {
 			margin-top: -0.125rem;
 		}
 	}

--- a/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/resources/META-INF/resources/init.jsp
@@ -20,9 +20,7 @@
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
 taglib uri="http://liferay.com/tld/product-navigation" prefix="liferay-product-navigation" %><%@
-taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
-taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
-taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 
 <%@ page import="com.liferay.portal.kernel.model.UserNotificationEvent" %><%@
 page import="com.liferay.portal.kernel.portlet.PortletProvider" %><%@

--- a/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/resources/META-INF/resources/view.jsp
@@ -19,28 +19,10 @@
 <c:choose>
 	<c:when test="<%= themeDisplay.isSignedIn() %>">
 		<span class="user-avatar-link">
-			<liferay-util:buffer
-				var="userAvatar"
-			>
-				<span class="sticker sticker-lg">
-					<span class="inline-item">
-						<liferay-ui:user-portrait
-							cssClass="sticker-lg"
-							user="<%= user %>"
-						/>
-					</span>
-
-					<c:if test="<%= themeDisplay.isImpersonated() %>">
-						<span class="sticker sticker-bottom-right sticker-circle sticker-outside sticker-sm sticker-user-icon">
-							<aui:icon image="user" markupView="lexicon" />
-						</span>
-					</c:if>
-				</span>
-			</liferay-util:buffer>
-
 			<liferay-product-navigation:personal-menu
 				expanded="<%= true %>"
-				label="<%= userAvatar %>"
+				size="lg"
+				user="<%= user %>"
 			/>
 
 			<%

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/package.json
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/package.json
@@ -2,7 +2,7 @@
 	"dependencies": {
 		"@clayui/button": "3.0.1",
 		"@clayui/data-provider": "3.0.1",
-		"@clayui/drop-down": "3.0.1",
+		"@clayui/drop-down": "3.1.0",
 		"@clayui/form": "3.1.0",
 		"@clayui/icon": "3.0.1",
 		"@clayui/link": "3.0.1",

--- a/modules/dxp/apps/segments/segments-experiment-web/package.json
+++ b/modules/dxp/apps/segments/segments-experiment-web/package.json
@@ -2,7 +2,7 @@
 	"dependencies": {
 		"@clayui/alert": "3.0.0",
 		"@clayui/button": "3.0.1",
-		"@clayui/drop-down": "3.0.1",
+		"@clayui/drop-down": "3.1.0",
 		"@clayui/form": "3.1.0",
 		"@clayui/icon": "3.0.1",
 		"@clayui/link": "3.0.1",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -1103,15 +1103,15 @@
     classnames "^2.2.6"
     moment "^2.22.2"
 
-"@clayui/drop-down@3.0.1", "@clayui/drop-down@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@clayui/drop-down/-/drop-down-3.0.1.tgz#a7b19ce555cff9d3bd2a02423d6ea651305c3b14"
-  integrity sha512-+CLTIAk2A3UnUBx6vFplC8lM85GPseyH+I3QulE9TwQ498Y5kegR08sR+n+Peh1dkTLI1tnE1tfjzQiSs27Sog==
+"@clayui/drop-down@3.1.0", "@clayui/drop-down@^3.0.1":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@clayui/drop-down/-/drop-down-3.1.0.tgz#666e78ab5d2ecfa5afd8728007b91273ff6d8e9a"
+  integrity sha512-Qcsoe7v1qk4OpMdOtzC9cu5KCxRF4VlgVlypsEfg/IOXgCzF/x43Ak38c5R932UCflIUbIA+5tazriqDe7KnSg==
   dependencies:
     "@clayui/button" "^3.0.1"
     "@clayui/form" "^3.1.0"
     "@clayui/icon" "^3.0.1"
-    "@clayui/shared" "^3.0.2"
+    "@clayui/shared" "^3.0.3"
     classnames "^2.2.6"
     metal-position "^2.1.2"
     warning "^4.0.3"
@@ -1162,13 +1162,6 @@
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@clayui/loading-indicator/-/loading-indicator-3.0.0.tgz#778b4e9ac19a4f65b9457ac42df9caa851d4a645"
   integrity sha512-vy5EzKKaGyFPHdkakZ3dVE+AiJJraM7jRW7X1V0+FSURp/17KGa+bIcheXSxq38JKBtafLvlvRNH/yMaR488Yw==
-  dependencies:
-    classnames "^2.2.6"
-
-"@clayui/management-toolbar@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@clayui/management-toolbar/-/management-toolbar-3.0.0.tgz#32e2dcc6e666be6a6aeab2ab5e04883d02552562"
-  integrity sha512-Nf3NaS47X+oTDm+5X//8Fm5w/pviPL4UsHYhNQmahTJaHtixTsP8xMzHRhHD/3lFRhWI7QLzR4k46FFzytFYNQ==
   dependencies:
     classnames "^2.2.6"
 
@@ -1281,10 +1274,18 @@
     classnames "^2.2.6"
     warning "^4.0.3"
 
-"@clayui/shared@3.0.2", "@clayui/shared@^3.0.2":
+"@clayui/shared@3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@clayui/shared/-/shared-3.0.2.tgz#29d1cc139a1adaa3d35bcd82f98f068938cf8987"
   integrity sha512-sWOlVD4mn6QC62NhvIO7UYCZsFynKf4zHzIzfTL9yvgY52R6RtBxXbJl9KUaxoFEtM9qCBpSO6r7pXk/tSkESA==
+  dependencies:
+    "@clayui/button" "^3.0.1"
+    "@clayui/link" "^3.0.1"
+
+"@clayui/shared@^3.0.2", "@clayui/shared@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@clayui/shared/-/shared-3.0.3.tgz#b60c921114b007bc33c30a48e37dd805dac22a90"
+  integrity sha512-gBt+iFWfqJ8fV11Mz6bKMLilMtQn+4c34ZrbMiMQgLbI9cZbBhl6rBYiYC1kXYzmZzYgKrCN8cJBUd31laph9w==
   dependencies:
     "@clayui/button" "^3.0.1"
     "@clayui/link" "^3.0.1"
@@ -7294,7 +7295,7 @@ error@^7.0.0:
     string-template "~0.2.1"
     xtend "~4.0.0"
 
-es-abstract@^1.10.0, es-abstract@^1.11.0, es-abstract@^1.12.0, es-abstract@^1.13.0, es-abstract@^1.15.0, es-abstract@^1.4.3, es-abstract@^1.5.1, es-abstract@^1.7.0, es-abstract@^1.9.0:
+es-abstract@^1.10.0, es-abstract@^1.12.0, es-abstract@^1.13.0, es-abstract@^1.15.0, es-abstract@^1.4.3, es-abstract@^1.5.1, es-abstract@^1.7.0, es-abstract@^1.9.0:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.16.0.tgz#d3a26dc9c3283ac9750dca569586e976d9dcc06d"
   integrity sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==


### PR DESCRIPTION
Hey @drewbrokke, @pei-jung, this adds back the `label` feature, so it can be passed down to the tag and will be used as the trigger.

Additionally, we've already added the necessary fixes so the dropdown does not have scroll.

Please, could you take a look, see if there's still anything missing and push it forward otherwise?

Thanks!