### PR TITLE
[TS] LPS-122283 Set groupIds to -1 so that the GroupIdQueryPreFilterContributor will not include the Active/InactiveGroupsBooleanFilter since Users and Organizations don't belong to any of them themselves

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
@@ -2167,6 +2167,7 @@ public class OrganizationLocalServiceImpl
 
 		searchContext.setCompanyId(companyId);
 		searchContext.setEnd(end);
+		searchContext.setGroupIds(new long[] {-1L});
 
 		if (params != null) {
 			String keywords = (String)params.remove("keywords");

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -6036,6 +6036,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 		searchContext.setCompanyId(companyId);
 		searchContext.setEnd(end);
+		searchContext.setGroupIds(new long[] {-1L});
 
 		if (params != null) {
 			String keywords = (String)params.remove("keywords");


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-122283

If you have inactive groupIds, they are added to the search query by the GroupIdQueryPreFilterContributor.

That can cause problems if you have a large number of inactive users (because users have an entry in group_ table).

Users and Organizations doesn't have any groupId indexed in the Elasticsearch, so it is worthless to add this filter, to avoid adding this filter, we can set this filter to "-1", that will disable the groupId filter that is added in GroupIdQueryPreFilterContributor.

The same solution of filtering using "-1" value is already applied in both the segmentation and workflows functionalities, see:

- Segmentation: https://github.com/liferay/liferay-portal/commit/7a8a2bdf3fa9024512484264756b1922f2fc0438
- Workflow:  https://github.com/liferay/liferay-portal/commit/e35d2a5b1743663cd13f3f14030772b0abaa339f