### PR TITLE
LPS-122000 Add new service Impl methods to account for Regions

### DIFF
--- a/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/service/test/CountryLocalServiceTest.java
+++ b/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/service/test/CountryLocalServiceTest.java
@@ -70,6 +70,14 @@ public class CountryLocalServiceTest {
 
 		Assert.assertNotNull(
 			_countryLocalService.fetchCountry(country.getCountryId()));
+	}
+
+	@Test
+	public void testDeleteCountry() throws Exception {
+		Country country = _addCountry(
+			RandomTestUtil.randomBoolean(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomDouble(), RandomTestUtil.randomBoolean(),
+			RandomTestUtil.randomBoolean(), RandomTestUtil.randomBoolean());
 
 		Organization organization = OrganizationTestUtil.addOrganization();
 

--- a/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/service/test/CountryLocalServiceTest.java
+++ b/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/service/test/CountryLocalServiceTest.java
@@ -16,9 +16,12 @@ package com.liferay.address.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.model.Address;
 import com.liferay.portal.kernel.model.Country;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.OrganizationConstants;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.AddressLocalService;
 import com.liferay.portal.kernel.service.CountryLocalService;
 import com.liferay.portal.kernel.service.OrganizationLocalService;
 import com.liferay.portal.kernel.service.RegionService;
@@ -26,6 +29,7 @@ import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -73,7 +77,34 @@ public class CountryLocalServiceTest {
 	}
 
 	@Test
-	public void testDeleteCountry() throws Exception {
+	public void testDeleteCountryDeleteAddress() throws Exception {
+		Country country = _addCountry(
+			RandomTestUtil.randomBoolean(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomDouble(), RandomTestUtil.randomBoolean(),
+			RandomTestUtil.randomBoolean(), RandomTestUtil.randomBoolean());
+
+		User user = TestPropsValues.getUser();
+
+		Address address = _addressLocalService.addAddress(
+			null, user.getUserId(), null, user.getContactId(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), null, null,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), 0,
+			country.getCountryId(), RandomTestUtil.randomLong(), false, false,
+			"1234567890", ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertEquals(country.getCountryId(), address.getCountryId());
+
+		_countryLocalService.deleteCountry(country);
+
+		Assert.assertNull(
+			_addressLocalService.fetchAddress(address.getAddressId()));
+		Assert.assertNull(
+			_countryLocalService.fetchCountry(country.getCountryId()));
+	}
+
+	@Test
+	public void testDeleteCountryUpdateOrganization() throws Exception {
 		Country country = _addCountry(
 			RandomTestUtil.randomBoolean(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomDouble(), RandomTestUtil.randomBoolean(),
@@ -151,6 +182,9 @@ public class CountryLocalServiceTest {
 			subjectToVAT, zipRequired,
 			ServiceContextTestUtil.getServiceContext());
 	}
+
+	@Inject
+	private static AddressLocalService _addressLocalService;
 
 	@Inject
 	private static CountryLocalService _countryLocalService;

--- a/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/service/test/RegionLocalServiceTest.java
+++ b/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/service/test/RegionLocalServiceTest.java
@@ -61,6 +61,13 @@ public class RegionLocalServiceTest {
 
 		Assert.assertNotNull(
 			_regionLocalService.fetchRegion(region.getRegionId()));
+	}
+
+	@Test
+	public void testDeleteRegionDeleteAddress() throws Exception {
+		Country country = _addCountry();
+
+		Region region = _addRegion(country.getCountryId());
 
 		User user = TestPropsValues.getUser();
 
@@ -85,7 +92,7 @@ public class RegionLocalServiceTest {
 	}
 
 	@Test
-	public void testDeleteRegion() throws Exception {
+	public void testDeleteRegionUpdateOrganization() throws Exception {
 		Country country = _addCountry();
 
 		Region region = _addRegion(country.getCountryId());

--- a/portal-impl/src/com/liferay/portal/service/base/CountryLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/CountryLocalServiceBaseImpl.java
@@ -142,10 +142,11 @@ public abstract class CountryLocalServiceBaseImpl
 	 *
 	 * @param country the country
 	 * @return the country that was removed
+	 * @throws PortalException
 	 */
 	@Indexable(type = IndexableType.DELETE)
 	@Override
-	public Country deleteCountry(Country country) {
+	public Country deleteCountry(Country country) throws PortalException {
 		return countryPersistence.remove(country);
 	}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/CountryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CountryLocalServiceImpl.java
@@ -86,7 +86,7 @@ public class CountryLocalServiceImpl extends CountryLocalServiceBaseImpl {
 	}
 
 	@Override
-	public void deleteCompanyCountries(long companyId) {
+	public void deleteCompanyCountries(long companyId) throws PortalException {
 		List<Country> countries = countryPersistence.findByCompanyId(companyId);
 
 		for (Country country : countries) {

--- a/portal-impl/src/com/liferay/portal/service/impl/RegionServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RegionServiceImpl.java
@@ -130,7 +130,6 @@ public class RegionServiceImpl extends RegionServiceBaseImpl {
 			_getOrderByComparator(countryId));
 	}
 
-	@AccessControlled(guestAccessEnabled = true)
 	@Override
 	public List<Region> getRegions(
 		long countryId, boolean active, int start, int end,
@@ -140,7 +139,6 @@ public class RegionServiceImpl extends RegionServiceBaseImpl {
 			countryId, active, start, end, orderByComparator);
 	}
 
-	@AccessControlled(guestAccessEnabled = true)
 	@Override
 	public List<Region> getRegions(
 		long countryId, int start, int end,

--- a/portal-kernel/src/com/liferay/portal/kernel/service/CountryLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/CountryLocalService.java
@@ -101,7 +101,7 @@ public interface CountryLocalService
 	public PersistedModel createPersistedModel(Serializable primaryKeyObj)
 		throws PortalException;
 
-	public void deleteCompanyCountries(long companyId);
+	public void deleteCompanyCountries(long companyId) throws PortalException;
 
 	/**
 	 * Deletes the country from the database. Also notifies the appropriate model listeners.
@@ -112,10 +112,11 @@ public interface CountryLocalService
 	 *
 	 * @param country the country
 	 * @return the country that was removed
+	 * @throws PortalException
 	 */
 	@Indexable(type = IndexableType.DELETE)
 	@SystemEvent(type = SystemEventConstants.TYPE_DELETE)
-	public Country deleteCountry(Country country);
+	public Country deleteCountry(Country country) throws PortalException;
 
 	/**
 	 * Deletes the country with the primary key from the database. Also notifies the appropriate model listeners.

--- a/portal-kernel/src/com/liferay/portal/kernel/service/CountryLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/CountryLocalServiceUtil.java
@@ -86,7 +86,9 @@ public class CountryLocalServiceUtil {
 		return getService().createPersistedModel(primaryKeyObj);
 	}
 
-	public static void deleteCompanyCountries(long companyId) {
+	public static void deleteCompanyCountries(long companyId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
 		getService().deleteCompanyCountries(companyId);
 	}
 
@@ -99,9 +101,11 @@ public class CountryLocalServiceUtil {
 	 *
 	 * @param country the country
 	 * @return the country that was removed
+	 * @throws PortalException
 	 */
 	public static com.liferay.portal.kernel.model.Country deleteCountry(
-		com.liferay.portal.kernel.model.Country country) {
+			com.liferay.portal.kernel.model.Country country)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return getService().deleteCountry(country);
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/service/CountryLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/CountryLocalServiceWrapper.java
@@ -84,7 +84,9 @@ public class CountryLocalServiceWrapper
 	}
 
 	@Override
-	public void deleteCompanyCountries(long companyId) {
+	public void deleteCompanyCountries(long companyId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
 		_countryLocalService.deleteCompanyCountries(companyId);
 	}
 
@@ -97,10 +99,12 @@ public class CountryLocalServiceWrapper
 	 *
 	 * @param country the country
 	 * @return the country that was removed
+	 * @throws PortalException
 	 */
 	@Override
 	public com.liferay.portal.kernel.model.Country deleteCountry(
-		com.liferay.portal.kernel.model.Country country) {
+			com.liferay.portal.kernel.model.Country country)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _countryLocalService.deleteCountry(country);
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RegionService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RegionService.java
@@ -99,13 +99,11 @@ public interface RegionService extends BaseService {
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<Region> getRegions(long countryId, boolean active);
 
-	@AccessControlled(guestAccessEnabled = true)
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<Region> getRegions(
 		long countryId, boolean active, int start, int end,
 		OrderByComparator<Region> orderByComparator);
 
-	@AccessControlled(guestAccessEnabled = true)
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<Region> getRegions(
 		long countryId, int start, int end,


### PR DESCRIPTION
Hey Brian, 

We're keeping the `@AccessControlled` annotation in Country service as a replacement for the deprecated method `getCountries(boolean active)`. These annotations were originally added in https://issues.liferay.com/browse/LPS-61153.

/cc @drewbrokke @alee8888