### PR TITLE
LPS-125956 Truncate text of role or team name and add tooltip

### DIFF
--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
@@ -66,18 +66,25 @@ if (Validator.isNotNull(portletConfigurationPermissionsDisplayContext.getModelRe
 						RoleTypeContributor roleTypeContributor = roleTypeContributorProvider.getRoleTypeContributor(role.getType());
 						%>
 
-						<liferay-ui:icon
-							icon='<%= (roleTypeContributor != null) ? roleTypeContributor.getIcon() : "users" %>'
-							label="<%= false %>"
-							markupView="lexicon"
-							message='<%= LanguageUtil.get(request, (roleTypeContributor != null) ? roleTypeContributor.getTitle(locale) : "team") %>'
-						/>
+						<span class="text-truncate-inline">
+							<span class="inline-item-before">
+								<liferay-ui:icon
+									icon='<%= (roleTypeContributor != null) ? roleTypeContributor.getIcon() : "users" %>'
+									label="<%= false %>"
+									markupView="lexicon"
+									message='<%= LanguageUtil.get(request, (roleTypeContributor != null) ? roleTypeContributor.getTitle(locale) : "team") %>'
+								/>
+							</span>
+							<span class="lfr-portal-tooltip text-truncate" title="<%= role.getTitle(locale) %>">
+								<%= role.getTitle(locale) %>
+							</span>
 
-						<%= role.getTitle(locale) %>
-
-						<c:if test="<%= layout.isPrivateLayout() && name.equals(RoleConstants.GUEST) %>">
-							<liferay-ui:icon-help message="under-the-current-configuration-all-users-automatically-inherit-permissions-from-the-guest-role" />
-						</c:if>
+							<c:if test="<%= layout.isPrivateLayout() && name.equals(RoleConstants.GUEST) %>">
+								<span class="inline-item-after">
+									<liferay-ui:icon-help message="under-the-current-configuration-all-users-automatically-inherit-permissions-from-the-guest-role" />
+								</span>
+							</c:if>
+						</span>
 					</liferay-ui:search-container-column-text>
 
 					<%


### PR DESCRIPTION
Truncating the text may result in ambiguous names, so it's necessary to
provide a tooltip as well. Also, spacing and alignment issues were
addressed after wrapping the content.