### PR TITLE
LPS-127860 URL in mail verification has 'nullnull' after creating a new virtual instance

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -264,6 +264,15 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		boolean sendEmail = false;
 		ServiceContext serviceContext = new ServiceContext();
 
+		Company company = companyLocalService.getCompany(companyId);
+
+		serviceContext.setPathMain(PortalUtil.getPathMain());
+
+		String portalURL = PortalUtil.getPortalURL(
+			company.getVirtualHostname(), -1, false);
+
+		serviceContext.setPortalURL(portalURL);
+
 		User defaultAdminUser = addUser(
 			creatorUserId, companyId, autoPassword, password1, password2,
 			autoScreenName, screenName, emailAddress, facebookId, openId,


### PR DESCRIPTION
Hi @pei-jung 

Could you please review this pull request?

This code set the missing `portalURL` and `pathMain` parts of the verification URL.
However, I couldn't figure out a way the get the server port because no `request` object is available.

Are there any services in our codebase that can be used to determine the port without `request`?

@drewbrokke

Thank you and best regards,
István