### PR TITLE
LPS-129254 Use redirect to fill the back button of edit configuration.

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/edit_configuration.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/edit_configuration.jsp
@@ -64,7 +64,7 @@ if (configurationModel.isFactory()) {
 }
 
 portletDisplay.setShowBackIcon(true);
-portletDisplay.setURLBack(portletURL.toString());
+portletDisplay.setURLBack(redirect);
 
 renderResponse.setTitle(categoryDisplayName);
 %>


### PR DESCRIPTION
**Motivation**
As part of https://issues.liferay.com/browse/LPS-119068, we need to make the back button of the System Settings Configuration configurable:
 
![Screenshot 2021-03-16 at 14 09 25](https://user-images.githubusercontent.com/5776822/111314772-01cc1100-8662-11eb-9784-dad7ef057af9.png)

**Proposed Solution**

Use the redirect parameter to fill the back button.

**How to test it**

1. Go to System Settings > Segments > Segments Analytics Cloud
3. Check that when you click the back button you are redirected to the System Settings Panel 
4. Go again to System Settings > Segments > Segments Analytics Cloud, the URL should be something like: http://localhost:8080/group/control_panel/manage?p_p_id=com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet&p_p_lifecycle=0&p_p_state=maximized&p_p_mode=view&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_factoryPid=com.liferay.segments.asah.connector.internal.configuration.SegmentsAsahConfiguration&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_mvcRenderCommandName=%2Fconfiguration_admin%2Fedit_configuration&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_pid=com.liferay.segments.asah.connector.internal.configuration.SegmentsAsahConfiguration
5. Add a redirect param to the URL: &_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_redirect=http://localhost:8080
6. Check that when you click the back button you are redirected to the Home page.

