### PR TITLE
[TS] LPS-129270

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/portlet/InstanceSettingsControlPanelEntry.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/portlet/InstanceSettingsControlPanelEntry.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.configuration.admin.web.internal.portlet;
+
+import com.liferay.configuration.admin.constants.ConfigurationAdminPortletKeys;
+import com.liferay.portal.kernel.portlet.ControlPanelEntry;
+import com.liferay.portal.kernel.portlet.OmniadminControlPanelEntry;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Christopher Kian
+ */
+@Component(
+	immediate = true,
+	property = "javax.portlet.name=" + ConfigurationAdminPortletKeys.INSTANCE_SETTINGS,
+	service = ControlPanelEntry.class
+)
+public class InstanceSettingsControlPanelEntry
+	extends OmniadminControlPanelEntry {
+}

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/portlet/InstanceSettingsControlPanelEntry.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/portlet/InstanceSettingsControlPanelEntry.java
@@ -15,8 +15,8 @@
 package com.liferay.configuration.admin.web.internal.portlet;
 
 import com.liferay.configuration.admin.constants.ConfigurationAdminPortletKeys;
+import com.liferay.portal.kernel.portlet.AdministratorControlPanelEntry;
 import com.liferay.portal.kernel.portlet.ControlPanelEntry;
-import com.liferay.portal.kernel.portlet.OmniadminControlPanelEntry;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -29,5 +29,5 @@ import org.osgi.service.component.annotations.Component;
 	service = ControlPanelEntry.class
 )
 public class InstanceSettingsControlPanelEntry
-	extends OmniadminControlPanelEntry {
+	extends AdministratorControlPanelEntry {
 }

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/java/com/liferay/marketplace/app/manager/web/internal/portlet/MarketplaceAppManagerControlPanelEntry.java
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/java/com/liferay/marketplace/app/manager/web/internal/portlet/MarketplaceAppManagerControlPanelEntry.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.marketplace.app.manager.web.internal.portlet;
+
+import com.liferay.marketplace.app.manager.web.internal.constants.MarketplaceAppManagerPortletKeys;
+import com.liferay.portal.kernel.portlet.ControlPanelEntry;
+import com.liferay.portal.kernel.portlet.OmniadminControlPanelEntry;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Christopher Kian
+ */
+@Component(
+	immediate = true,
+	property = "javax.portlet.name=" + MarketplaceAppManagerPortletKeys.MARKETPLACE_APP_MANAGER,
+	service = ControlPanelEntry.class
+)
+public class MarketplaceAppManagerControlPanelEntry
+	extends OmniadminControlPanelEntry {
+}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-129270

Both portlets will throw PrincipalExceptions when they are accessed by any user aside from an omniadmin [[1](https://github.com/liferay/liferay-portal/blob/master/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/portlet/InstanceSettingsPortlet.java#L92-L98)][[2](https://github.com/liferay/liferay-portal/blob/master/modules/apps/marketplace/marketplace-app-manager-web/src/main/java/com/liferay/marketplace/app/manager/web/internal/portlet/MarketplaceAppManagerPortlet.java#L384-L390)].  Therefore, we should have them extend OmniadminControlPanelEntry class so they are [no longer displayed when editing a role's permission](https://github.com/liferay/liferay-portal/blob/master/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role_permissions_navigation.jspf#L357-L359).

Please let me know if you have any questions, thanks!