### PR TITLE
[TS] LPS-128759

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -6015,7 +6015,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		Map<String, Serializable> attributes = new HashMap<>();
 
 		if (params != null) {
-			Long groupId = (Long)params.remove(Field.GROUP_ID);
+			Long groupId = (Long)params.get(Field.GROUP_ID);
 
 			if (groupId == null) {
 				groupId = 0L;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPP-40515
https://issues.liferay.com/browse/LPS-128759

From @wanderlast:

> I'm sending this to you since this deals with USM and it has potentially pretty broad implications (e.g. if other things were designed around the behavior I'm changing). I've tested it and I don't believe it should cause anything to act incorrectly, but it's certainly possible I've missed cases so I wanted your eyes on it first.
> 
> The issue we're seeing is that site admins can't add new users to a site since the users don't appear in the 'add users' menu window. However the cause of this issue is actually more of a technical issue than a logical issue. In LPS-119517 we made changes to how we process parameters before adding them to our search context. This change includes switching from getOrDefault to removing the parameter (specifically https://github.com/liferay/liferay-portal/commit/42788cc8912e69ec2de12f0302271717c0022902):
> 
> Long groupId = (Long)params.remove(Field.GROUP_ID);
> 
> However, since these parameters are actually being passed by reference, what happens is that we remove and therefore lose the groupID completely. This means that in cases like [here](https://github.com/liferay/liferay-portal/blob/8ac2ffe7464930561997a72cd5f951144f43358c/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectUsersDisplayContext.java#L203-L202) where we use the same LinkedHashMap of params to pass to two different methods the count method recognizes the correct groupID, but the actual search is provided a groupID of 0L and therefore returns incorrect permissions. I've therefore switched remove back to get, keeping the rest of the logic the same since it should theoretically act in a similar manner beyond not removing the parameter.
> 
> Please let me know if you have any questions or if I can clarify anything. Thanks!