### PR TITLE
LPS-129699 Remove Liferay.Util.selectEntityHandler usages from roles

### DIFF
--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_regular_role.jspf
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_regular_role.jspf
@@ -84,10 +84,3 @@ SearchContainer<Role> roleSearchContainer = selectRoleManagementToolbarDisplayCo
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<aui:script use="aui-base">
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />selectRegularRoleFm',
-		'<%= HtmlUtil.escapeJS(eventName) %>'
-	);
-</aui:script>

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_site_role.jspf
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_site_role.jspf
@@ -248,13 +248,6 @@ SearchContainer<Role> roleSearchContainer = selectRoleManagementToolbarDisplayCo
 					markupView="lexicon"
 				/>
 			</liferay-ui:search-container>
-
-			<aui:script use="aui-base">
-				Liferay.Util.selectEntityHandler(
-					'#<portlet:namespace />selectSiteRoleFm',
-					'<%= HtmlUtil.escapeJS(eventName) %>'
-				);
-			</aui:script>
 		</c:when>
 	</c:choose>
 </aui:form>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
@@ -588,57 +588,49 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 					'.modify-link'
 				);
 
-				A.one('#<portlet:namespace />selectSiteRoleLink').on('click', (event) => {
-					var searchContainerName = '<portlet:namespace />siteRolesSearchContainer';
+				<%
+				String siteRoleEventName = liferayPortletResponse.getNamespace() + "selectSiteRole";
 
-					var searchContainer = Liferay.SearchContainer.get(searchContainerName);
+				PortletURL selectSiteRoleURL = PortletURLBuilder.create(
+					PortletProviderUtil.getPortletURL(request, Role.class.getName(), PortletProvider.Action.BROWSE)
+				).setParameter(
+					"p_u_i_d", (selUser == null) ? "0" : String.valueOf(selUser.getUserId())
+				).setParameter(
+					"step", "1"
+				).setParameter(
+					"roleType", String.valueOf(RoleConstants.TYPE_SITE)
+				).setParameter(
+					"eventName", siteRoleEventName
+				).setWindowState(
+					LiferayWindowState.POP_UP
+				).build();
+				%>
 
-					Util.selectEntity(
-						{
-							dialog: {
-								constrain: true,
-								modal: true,
+				const selectSiteRoleLink = document.getElementById(
+					'<portlet:namespace />selectSiteRoleLink'
+				);
+
+				if (selectSiteRoleLink) {
+					selectSiteRoleLink.addEventListener('click', (event) => {
+						Util.openSelectionModal({
+							onSelect: (selectedItem) => {
+								<portlet:namespace />selectRole(
+									selectedItem.entityid,
+									selectedItem.entityname,
+									selectedItem.searchcontainername,
+									selectedItem.groupdescriptivename,
+									selectedItem.groupid,
+									selectedItem.iconcssclass
+								);
 							},
-
-							<%
-							String siteRoleEventName = liferayPortletResponse.getNamespace() + "selectSiteRole";
-							%>
-
-							id: '<%= siteRoleEventName %>',
+							selectEventName: '<%= siteRoleEventName %>',
 							selectedData: searchContainer.getData(true),
 							title:
 								'<liferay-ui:message arguments="site-role" key="select-x" />',
-
-							<%
-							PortletURL selectSiteRoleURL = PortletURLBuilder.create(
-								PortletProviderUtil.getPortletURL(request, Role.class.getName(), PortletProvider.Action.BROWSE)
-							).setParameter(
-								"p_u_i_d", (selUser == null) ? "0" : String.valueOf(selUser.getUserId())
-							).setParameter(
-								"step", "1"
-							).setParameter(
-								"roleType", String.valueOf(RoleConstants.TYPE_SITE)
-							).setParameter(
-								"eventName", siteRoleEventName
-							).setWindowState(
-								LiferayWindowState.POP_UP
-							).build();
-							%>
-
-							uri: '<%= selectSiteRoleURL.toString() %>',
-						},
-						(event) => {
-							<portlet:namespace />selectRole(
-								event.entityid,
-								event.entityname,
-								event.searchcontainername,
-								event.groupdescriptivename,
-								event.groupid,
-								event.iconcssclass
-							);
-						}
-					);
-				});
+							url: '<%= selectSiteRoleURL.toString() %>',
+						});
+					});
+				}
 			</aui:script>
 		</c:if>
 	</c:if>


### PR DESCRIPTION
Hi Pei-Jung, sending you this because I can't find the home of Users & System Management team.

This PR removes usages of `Liferay.Util.selectEntityHandler` inside `roles-admin-web`. I've manually tested the changes to make sure modals work as they did before.

Initial PR can be found in https://github.com/liferay-frontend/liferay-portal/pull/950 where it has been initially reviewed.

## 🧪 Testing
1. Open the Control Panel and go to Users and Organizations
2. Create a new user
3. Click on Roles in the left navigation
4. `Select` Regular roles, and `Select` Site roles