### PR TITLE
LPS-129587 Migrate selection modals in users-admin

### DIFF
--- a/modules/apps/site/site-browser-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/site/site-browser-web/src/main/resources/META-INF/resources/view.jsp
@@ -116,11 +116,3 @@
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<aui:script>
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />selectGroupFm',
-		'<%= HtmlUtil.escapeJS(siteBrowserDisplayContext.getEventName()) %>',
-		<%= siteBrowserDisplayContext.getSelUser() != null %>
-	);
-</aui:script>

--- a/modules/apps/users-admin/users-admin-item-selector-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/users-admin/users-admin-item-selector-web/src/main/resources/META-INF/resources/init.jsp
@@ -18,8 +18,7 @@
 
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
-<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
-taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>

--- a/modules/apps/users-admin/users-admin-item-selector-web/src/main/resources/META-INF/resources/user_item_selector.jsp
+++ b/modules/apps/users-admin/users-admin-item-selector-web/src/main/resources/META-INF/resources/user_item_selector.jsp
@@ -102,39 +102,3 @@ String displayStyle = userItemSelectorViewDisplayContext.getDisplayStyle();
 		/>
 	</liferay-ui:search-container>
 </clay:container-fluid>
-
-<aui:script use="liferay-search-container">
-	var searchContainer = Liferay.SearchContainer.get(
-		'<portlet:namespace /><%= HtmlUtil.escape(userItemSelectorViewDisplayContext.getSearchContainerId()) %>'
-	);
-
-	searchContainer.on('rowToggled', (event) => {
-		var allSelectedElements = event.elements.allSelectedElements;
-		var selectedData = [];
-
-		allSelectedElements.each(function () {
-			<c:choose>
-				<c:when test='<%= displayStyle.equals("list") %>'>
-					var row = this.ancestor('tr');
-				</c:when>
-				<c:otherwise>
-					var row = this.ancestor('li');
-				</c:otherwise>
-			</c:choose>
-
-			var data = row.getDOM().dataset;
-
-			selectedData.push({
-				id: data.id,
-				name: data.name,
-			});
-		});
-
-		Liferay.Util.getOpener().Liferay.fire(
-			'<%= HtmlUtil.escapeJS(userItemSelectorViewDisplayContext.getItemSelectedEventName()) %>',
-			{
-				data: selectedData,
-			}
-		);
-	});
-</aui:script>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/js/actions.es.js
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/js/actions.es.js
@@ -33,8 +33,8 @@ export const ACTIONS = {
 		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('done'),
 			multiple: true,
-			onSelect: (data) => {
-				if (data) {
+			onSelect: (selectedItems) => {
+				if (selectedItems?.length) {
 					const assignmentsRedirectURL = createRenderURL(
 						basePortletURL,
 						{
@@ -45,8 +45,10 @@ export const ACTIONS = {
 						}
 					);
 
+					const values = selectedItems.map((item) => item.value);
+
 					const editAssignmentURL = createActionURL(basePortletURL, {
-						addUserIds: data.value,
+						addUserIds: values.join(','),
 						assignmentsRedirect: assignmentsRedirectURL.toString(),
 						'javax.portlet.action':
 							'/users_admin/edit_organization_assignments',
@@ -64,7 +66,6 @@ export const ACTIONS = {
 					submitForm(form, editAssignmentURL.toString());
 				}
 			},
-			selectEventName: `${portletNamespace}selectUsers`,
 			title: Liferay.Language.get('assign-users'),
 			url: selectUsersURL.toString(),
 		});

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/select_organization.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/select_organization.jsp
@@ -18,7 +18,6 @@
 
 <%
 String p_u_i_d = ParamUtil.getString(request, "p_u_i_d");
-String eventName = ParamUtil.getString(request, "eventName", liferayPortletResponse.getNamespace() + "selectOrganization");
 
 long selOrganizationId = ParamUtil.getLong(request, "organizationId");
 User selUser = PortalUtil.getSelectedUser(request);
@@ -134,11 +133,3 @@ renderResponse.setTitle(LanguageUtil.get(request, "organizations"));
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<aui:script use="aui-base">
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />selectOrganizationFm',
-		'<%= HtmlUtil.escapeJS(eventName) %>',
-		<%= selUser != null %>
-	);
-</aui:script>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/select_organization_users.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/select_organization_users.jsp
@@ -32,8 +32,6 @@ else {
 	request.setAttribute(WebKeys.SINGLE_PAGE_APPLICATION_CLEAR_CACHE, Boolean.TRUE);
 }
 
-String eventName = ParamUtil.getString(request, "eventName", liferayPortletResponse.getNamespace() + "selectUsers");
-
 SelectOrganizationUsersManagementToolbarDisplayContext selectOrganizationUsersManagementToolbarDisplayContext = new SelectOrganizationUsersManagementToolbarDisplayContext(request, renderRequest, renderResponse, organization, displayStyle);
 
 PortletURL portletURL = selectOrganizationUsersManagementToolbarDisplayContext.getPortletURL();
@@ -121,26 +119,3 @@ SearchContainer<User> userSearchContainer = selectOrganizationUsersManagementToo
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<aui:script use="liferay-search-container">
-	var searchContainer = Liferay.SearchContainer.get('<portlet:namespace />users');
-
-	searchContainer.on('rowToggled', (event) => {
-		var selectedItems = event.elements.allSelectedElements;
-
-		var result = {};
-
-		if (!selectedItems.isEmpty()) {
-			result = {
-				data: {
-					value: selectedItems.get('value').join(','),
-				},
-			};
-		}
-
-		Liferay.Util.getOpener().Liferay.fire(
-			'<%= HtmlUtil.escapeJS(eventName) %>',
-			result
-		);
-	});
-</aui:script>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/organizations.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/organizations.jsp
@@ -197,26 +197,14 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 
 		if (selectOrganizationLink) {
 			selectOrganizationLink.on('click', (event) => {
-				Util.selectEntity(
-					{
-						dialog: {
-							constrain: true,
-							modal: true,
-						},
-						id: '<portlet:namespace />selectOrganization',
-						selectedData: searchContainer.getData(true),
-						title:
-							'<liferay-ui:message arguments="organization" key="select-x" />',
-						uri:
-							'<portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcPath" value="/select_organization.jsp" /><portlet:param name="p_u_i_d" value='<%= (selUser == null) ? "0" : String.valueOf(selUser.getUserId()) %>' /></portlet:renderURL>',
-					},
-					(event) => {
-						var entityId = event.entityid;
+				Util.openSelectionModal({
+					onSelect: (selectedItem) => {
+						const entityId = selectedItem.entityid;
 
-						var rowColumns = [];
+						const rowColumns = [];
 
-						rowColumns.push(event.entityname);
-						rowColumns.push(event.type);
+						rowColumns.push(selectedItem.entityname);
+						rowColumns.push(selectedItem.type);
 						rowColumns.push('');
 						rowColumns.push(
 							'<a class="modify-link" data-rowId="' +
@@ -238,8 +226,14 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 						document.<portlet:namespace />fm.<portlet:namespace />deleteOrganizationIds.value = deleteOrganizationIds.join(
 							','
 						);
-					}
-				);
+					},
+					selectEventName: '<portlet:namespace />selectOrganization',
+					selectedData: [searchContainer.getData(true)],
+					title:
+						'<liferay-ui:message arguments="organization" key="select-x" />',
+					url:
+						'<portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcPath" value="/select_organization.jsp" /><portlet:param name="p_u_i_d" value='<%= (selUser == null) ? "0" : String.valueOf(selUser.getUserId()) %>' /></portlet:renderURL>',
+				});
 			});
 		}
 	</aui:script>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/sites.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/sites.jsp
@@ -155,47 +155,13 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 					searchContainerData = searchContainerData.split(',');
 				}
 
-				Util.selectEntity(
-					{
-						dialog: {
-							constrain: true,
-							modal: true,
-						},
+				Util.openSelectionModal({
+					onSelect: (selectedItem) => {
+						const entityId = selectedItem.entityid;
 
-						<%
-						String eventName = liferayPortletResponse.getNamespace() + "selectSite";
-						%>
+						const rowColumns = [];
 
-						id: '<%= eventName %>',
-						selectedData: searchContainerData,
-						title: '<liferay-ui:message arguments="site" key="select-x" />',
-
-						<%
-						PortletURL groupSelectorURL = PortletURLBuilder.create(
-							PortletProviderUtil.getPortletURL(request, Group.class.getName(), PortletProvider.Action.BROWSE)
-						).setParameter(
-							"eventName", eventName
-						).setParameter(
-							"filterManageableGroups", Boolean.FALSE.toString()
-						).setParameter(
-							"includeCurrentGroup", Boolean.FALSE.toString()
-						).setParameter(
-							"manualMembership", Boolean.TRUE.toString()
-						).setParameter(
-							"p_u_i_d", (selUser == null) ? "0" : String.valueOf(selUser.getUserId())
-						).setWindowState(
-							LiferayWindowState.POP_UP
-						).build();
-						%>
-
-						uri: '<%= groupSelectorURL.toString() %>',
-					},
-					(event) => {
-						var entityId = event.entityid;
-
-						var rowColumns = [];
-
-						rowColumns.push(event.entityname);
+						rowColumns.push(selectedItem.entityname);
 						rowColumns.push('');
 						rowColumns.push(
 							'<a class="modify-link" data-rowId="' +
@@ -217,8 +183,36 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 						document.<portlet:namespace />fm.<portlet:namespace />deleteGroupIds.value = deleteGroupIds.join(
 							','
 						);
-					}
-				);
+					},
+
+					<%
+					String eventName = liferayPortletResponse.getNamespace() + "selectSite";
+					%>
+
+					selectEventName: '<%= eventName %>',
+					selectedData: [searchContainerData],
+					title: '<liferay-ui:message arguments="site" key="select-x" />',
+
+					<%
+					PortletURL groupSelectorURL = PortletURLBuilder.create(
+						PortletProviderUtil.getPortletURL(request, Group.class.getName(), PortletProvider.Action.BROWSE)
+					).setParameter(
+						"p_u_i_d", (selUser == null) ? "0" : String.valueOf(selUser.getUserId())
+					).setParameter(
+						"filterManageableGroups", Boolean.FALSE.toString()
+					).setParameter(
+						"includeCurrentGroup", Boolean.FALSE.toString()
+					).setParameter(
+						"manualMembership", Boolean.TRUE.toString()
+					).setParameter(
+						"eventName", eventName
+					).setWindowState(
+						LiferayWindowState.POP_UP
+					).build();
+					%>
+
+					url: '<%= groupSelectorURL.toString() %>',
+				});
 			}
 		);
 


### PR DESCRIPTION
Hi @pei-jung, I'm forwarding this to you after getting some eyes on it at https://github.com/liferay-frontend/liferay-portal/pull/969. 

This PR migrates selection modals in `users-admin-web`, which caused the regression with these modals 10 days (or so) ago. There is a usage inside `site-browser-web` package that is related to some of the modals here in `users-admin` so I've included that as a separate commit.

# 🧪 Testing
## `site-browser-web/view.jsp` - `sites.jsp` modal
1. Create a new user and then edit it
2. Go to `Memberships` of that user
3. Click on `Select` in the `Sites` section

## `users-admin-web/select_organization.jsp` - `organizations.jsp` modal
1. Create an organization
2. Go to the previously created user and go to their `Organizations`
3. Click on `Select` in the `Organizations` section

## `users-admin-web/select_organization_users.jsp` - `users-admin-web/actions#selectUsers` modal
1. Go to the Organizations tab
2. Assign Users to your Organization
3. Select your existing user/s to add to the Organizations
4. Users are added to the Organization

## `user_item_selector.jsp`
_I haven't been able to find a usage of this file inside the Commerce Account portlet_. The other usage can be found:
1. Go to Site Admin Menu > People > Segments
2. Add a new user segment
3. Drag the User property from the sidebar to Conditions
4. Click on Select